### PR TITLE
Content Migration: OpenShift Virtualization Tutorials and Guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ dist
 
 # Local VSCode settings
 .vscode/settings*
+
+# Cursor AI project files
+.cursor/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 OpenShift Virtualization Cookbook
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/modules/LABENV/pages/index.adoc
+++ b/modules/LABENV/pages/index.adoc
@@ -1,27 +1,13 @@
 = Lab Environment
 
-== Instructions to Launch Your Lab on the Red Hat Demo Platform (RHDP)
+NOTE: Work in progress
 
-. **Log in** to the xref:#RHDP-Portal-Links[RHDP portal]
-. **Search** for the catalog entry: **FIXME Lab Catalog Name**.
-. **Click** on the catalog entry in the search results.
-. On the catalog page, **click** the **Order** button.
-. **Fill out** the required details in the order form.
-. **Review the warning** at the bottom of the form and **check the box** labeled: +
-   *“I confirm that I understand the above warnings.”*
-. **Click** the **Order** button to place your lab order.
+== Planned Lab Environment Guides
 
-=== Important Notes:
-- This lab may take approximately **FIXME minutes** to become ready.
-- You will receive an **email with access details** once your lab environment is ready.
-- You can also **retrieve lab access** directly from the RHDP portal.
+The following lab environment setup guides are planned for future releases:
 
-=== How to Access Your Lab via the RHDP Portal:
-. On the RHDP portal, **click** on the **Services** option in the left-hand menu.
-. **Select your lab** from the listings on the right-hand side of the page to view access details.
-
-[[RHDP-Portal-Links]]
-=== RHDP Portal Links
-- RedHat associates: https://demo.redhat.com/[https://demo.redhat.com/,window=_blank]
-- RedHat partners: https://partner.demo.redhat.com/[https://partner.demo.redhat.com/,window=_blank]
+* Bare metal home lab tutorial
+* Red Hat OpenShift Partner Labs
+* Cloud based lab tutorial
+* Nested virtualization using Podman or CRC
 

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,1 +1,5 @@
-* xref:index.adoc[]
+* xref:index.adoc[Home]
+** xref:getting-started:index.adoc[Getting Started]
+** xref:storage:index.adoc[Storage Configuration]
+** xref:networking:index.adoc[Networking Configuration]
+** xref:manifests:index.adoc[Manifests Reference]

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,27 +1,89 @@
-= An Example Quick Course
+= OpenShift Virtualization Cookbook
 :navtitle: Home
 
 == Introduction
 
-Course Title: Course title FIXME
+A bite-size approach reference for deploying virtualization workloads for those who are just starting with OpenShift.
 
-Description:
-Course description FIXME
+NOTE: This cookbook DOES NOT replace the official OpenShift Virtualization training, which is highly recommended, nor the official documentation. Instead, it is supposed to serve as a complement and a facilitator to partner and customer engineers just getting started.
 
-Duration: FIXME hours
+== What You'll Learn
 
-== Objectives
+This cookbook provides comprehensive, practical guidance on:
 
-On completing this course, you should be able to:
-
-* Observable, measurable objective...
-* Observable, measurable objective...
-* Observable, measurable objective...
+* Setting up and managing virtual machines on OpenShift
+* Configuring networking for various topologies and use cases
+* Managing storage for virtualization workloads
+* Using cloud-init for VM configuration and automation
+* Working with OpenShift Virtualization CLI tools
 
 == Prerequisites
 
-This course assumes that you have the following prior experience:
+To use this cookbook effectively, you should have:
 
-* Course or experience...
-* Course or experience...
-* Course or experience...
+* OpenShift 4.17+ cluster with OpenShift Virtualization operator installed
+* CLI tools: `oc`, `kubectl`, `virtctl`
+* Basic understanding of Kubernetes/OpenShift concepts
+* Familiarity with YAML and command-line tools
+
+Optional tools depending on your approach:
+
+* `kustomize`
+* `helm`
+* `ansible`
+
+== How to Use This Cookbook
+
+This cookbook is organized into focused modules:
+
+* **xref:getting-started:index.adoc[Getting Started]** - Essential tools and basic configuration
+* **xref:storage:index.adoc[Storage Configuration]** - Setting up storage for virtual machines
+* **xref:networking:index.adoc[Networking Configuration]** - Comprehensive networking guides
+* **xref:manifests:index.adoc[Manifests Reference]** - Ready-to-use YAML examples
+
+Each module contains step-by-step tutorials, practical examples, and troubleshooting guidance.
+
+== Quick Navigation
+
+=== Getting Started
+
+* xref:getting-started:prerequisites.adoc[Prerequisites and Setup]
+* xref:getting-started:virtctl-basics.adoc[Virtctl Basics]
+* xref:getting-started:storage-setup.adoc[Configuring Default Storage Class]
+
+=== Storage
+
+* xref:storage:lvm-operator.adoc[Installing LVM Storage Operator]
+* xref:storage:lvm-troubleshooting.adoc[Troubleshooting LVM Storage Operator]
+
+=== Networking
+
+* xref:networking:udn-primary-networks.adoc[Configuring Layer 2 Primary Networks with UDNs]
+* xref:networking:localnet-secondary.adoc[Configuring Localnet Secondary Networks with ClusterUserDefinedNetwork]
+* xref:networking:localnet-vlan.adoc[Configuring Localnet Secondary Networks with VLAN using NetworkAttachmentDefinition]
+* xref:networking:cudn-localnet-vlan.adoc[Configuring Localnet Secondary Networks with VLAN using ClusterUserDefinedNetwork]
+* xref:networking:linux-bridges.adoc[Configuring Linux Bridges for VMs]
+* xref:networking:ovs-bridge-verification.adoc[Troubleshooting OVS Bridge Creation for Localnet Networks]
+
+=== Manifests Reference
+
+* xref:manifests:operators.adoc[Operator Manifests]
+* xref:manifests:networking.adoc[Networking Manifests]
+* xref:manifests:storage.adoc[Storage Manifests]
+* xref:manifests:vms.adoc[Virtual Machine Manifests]
+* xref:manifests:security.adoc[Security Manifests]
+
+== Additional Resources
+
+* xref:appendix:glossary.adoc[Glossary] - Key terms and definitions
+* link:https://docs.openshift.com/container-platform/latest/virt/about_virt/about-virt.html[OpenShift Virtualization Documentation,window=_blank]
+* link:https://kubevirt.io/[KubeVirt Project,window=_blank]
+* link:https://cloudinit.readthedocs.io/[Cloud-init Documentation,window=_blank]
+
+== Contributing
+
+This cookbook is actively maintained. For questions, issues, or contributions, please refer to the link:https://github.com/RedHatQuickCourses/ocp-virt-cookbook[project repository,window=_blank].
+
+== License
+
+This project is licensed under the link:https://github.com/RedHatQuickCourses/ocp-virt-cookbook/blob/main/LICENSE[MIT License,window=_blank].

--- a/modules/appendix/nav.adoc
+++ b/modules/appendix/nav.adoc
@@ -1,1 +1,1 @@
-* xref:appendix.adoc[]
+* xref:glossary.adoc[Glossary]

--- a/modules/appendix/pages/appendix.adoc
+++ b/modules/appendix/pages/appendix.adoc
@@ -1,3 +1,0 @@
-= Appendix
-
-FIXME: Content for Appendix...

--- a/modules/appendix/pages/glossary.adoc
+++ b/modules/appendix/pages/glossary.adoc
@@ -1,0 +1,40 @@
+= Glossary
+:navtitle: Glossary
+
+== OpenShift Virtualization Terms
+
+**CNV**:: Container Native Virtualization, Red Hat's name for OpenShift Virtualization
+
+**NAD**:: NetworkAttachmentDefinition, defines additional networks for pods/VMs
+
+**NNCP**:: NodeNetworkConfigurationPolicy, NMState CR for configuring node networking
+
+**UDN**:: User Defined Network, custom networks with Layer 2 or Layer 3 connectivity
+
+**VLAN**:: Virtual LAN, network segmentation using VLAN tagging
+
+**OVS**:: Open vSwitch, software-based network switch
+
+**IPAM**:: IP Address Management, automatic IP allocation
+
+**PVC**:: PersistentVolumeClaim, request for storage
+
+**DataVolume**:: CDI CR for provisioning storage for VMs
+
+**VMI**:: VirtualMachineInstance, running VM instance
+
+**SCC**:: SecurityContextConstraint, OpenShift pod security policy
+
+**RBAC**:: Role-Based Access Control, Kubernetes authorization
+
+**Localnet**:: Network topology providing direct physical network access
+
+**Cloud-init**:: VM initialization tool for configuration
+
+**Virtctl**:: CLI tool for VM management
+
+== See Also
+
+* xref:getting-started:index.adoc[Getting Started] - Begin your OpenShift Virtualization journey
+* xref:ROOT:index.adoc[Home] - Return to the cookbook home page
+

--- a/modules/chapter1/nav.adoc
+++ b/modules/chapter1/nav.adoc
@@ -1,4 +1,0 @@
-* xref:index.adoc[]
-** xref:section1.adoc[]
-** xref:section2.adoc[]
-** xref:section3.adoc[]

--- a/modules/chapter1/pages/index.adoc
+++ b/modules/chapter1/pages/index.adoc
@@ -1,7 +1,0 @@
-= Chapter 1
-
-In this section, we cover... FIXME
-
-
-- Add or remove section entries in the `antora.yaml` file as needed.
-- Ensure you create or delete the corresponding directory for the chapter accordingly.

--- a/modules/chapter1/pages/section1.adoc
+++ b/modules/chapter1/pages/section1.adoc
@@ -1,6 +1,0 @@
-= Section 1
-
-* Create multiple copies of this section as needed.
-* Remove any unnecessary sections or chapter pages.
-* Customize the section as appropriate.
-* Ensure that each page contains a manageable amount of content.

--- a/modules/chapter1/pages/section2.adoc
+++ b/modules/chapter1/pages/section2.adoc
@@ -1,6 +1,0 @@
-= Section 2
-
-* Create multiple copies of this section as needed.
-* Remove any unnecessary sections or chapter pages.
-* Customize the section as appropriate.
-* Ensure that each page contains a manageable amount of content.

--- a/modules/chapter1/pages/section3.adoc
+++ b/modules/chapter1/pages/section3.adoc
@@ -1,6 +1,0 @@
-= Section 3
-
-* Create multiple copies of this section as needed.
-* Remove any unnecessary sections or chapter pages.
-* Customize the section as appropriate.
-* Ensure that each page contains a manageable amount of content.

--- a/modules/chapter2/nav.adoc
+++ b/modules/chapter2/nav.adoc
@@ -1,2 +1,0 @@
-* xref:index.adoc[]
-** xref:section1.adoc[]

--- a/modules/chapter2/pages/index.adoc
+++ b/modules/chapter2/pages/index.adoc
@@ -1,7 +1,0 @@
-= Chapter 2
-
-In this section, we cover... FIXME
-
-
-- Add or remove section entries in the `antora.yaml` file as needed.
-- Ensure you create or delete the corresponding directory for the chapter accordingly.

--- a/modules/chapter2/pages/section1.adoc
+++ b/modules/chapter2/pages/section1.adoc
@@ -1,6 +1,0 @@
-= Section 1
-
-* Create multiple copies of this section as needed.
-* Remove any unnecessary sections or chapter pages.
-* Customize the section as appropriate.
-* Ensure that each page contains a manageable amount of content.

--- a/modules/chapter3/nav.adoc
+++ b/modules/chapter3/nav.adoc
@@ -1,3 +1,0 @@
-* xref:index.adoc[]
-** xref:section1.adoc[]
-** xref:section2.adoc[]

--- a/modules/chapter3/pages/index.adoc
+++ b/modules/chapter3/pages/index.adoc
@@ -1,7 +1,0 @@
-= Chapter 3
-
-In this section, we cover... FIXME
-
-
-- Add or remove section entries in the `antora.yaml` file as needed.
-- Ensure you create or delete the corresponding directory for the chapter accordingly.

--- a/modules/chapter3/pages/section1.adoc
+++ b/modules/chapter3/pages/section1.adoc
@@ -1,6 +1,0 @@
-= Section 1
-
-* Create multiple copies of this section as needed.
-* Remove any unnecessary sections or chapter pages.
-* Customize the section as appropriate.
-* Ensure that each page contains a manageable amount of content.

--- a/modules/chapter3/pages/section2.adoc
+++ b/modules/chapter3/pages/section2.adoc
@@ -1,6 +1,0 @@
-= Section 2
-
-* Create multiple copies of this section as needed.
-* Remove any unnecessary sections or chapter pages.
-* Customize the section as appropriate.
-* Ensure that each page contains a manageable amount of content.

--- a/modules/getting-started/nav.adoc
+++ b/modules/getting-started/nav.adoc
@@ -1,0 +1,4 @@
+* xref:index.adoc[Getting Started]
+** xref:prerequisites.adoc[Prerequisites]
+** xref:virtctl-basics.adoc[Virtctl Basics]
+** xref:storage-setup.adoc[Storage Setup]

--- a/modules/getting-started/pages/index.adoc
+++ b/modules/getting-started/pages/index.adoc
@@ -1,0 +1,41 @@
+= Getting Started
+:navtitle: Getting Started
+
+== Overview
+
+This module covers the essential tools and basic configuration needed to start working with OpenShift Virtualization. Whether you're new to OpenShift Virtualization or looking to refresh your knowledge, these guides will help you get up and running quickly.
+
+== What You'll Learn
+
+In this section, you will learn:
+
+* Prerequisites and required tools for working with OpenShift Virtualization
+* Basic usage of the virtctl command-line tool for managing virtual machines
+* How to configure default storage for virtual machine deployments
+
+== Prerequisites
+
+Before proceeding with the tutorials in this section, ensure you have:
+
+* An OpenShift 4.17+ cluster with OpenShift Virtualization operator installed
+* Cluster admin access or appropriate RBAC permissions
+* CLI tools installed: `oc`, `kubectl`, `virtctl`
+* Basic understanding of Kubernetes/OpenShift concepts
+
+== Sections
+
+xref:prerequisites.adoc[Prerequisites and Setup]::
+Detailed requirements and setup instructions for working with OpenShift Virtualization.
+
+xref:virtctl-basics.adoc[Virtctl Basics]::
+Learn the essential virtctl commands for managing virtual machines.
+
+xref:storage-setup.adoc[Storage Setup]::
+Configure a default storage class for simplified VM deployment.
+
+== Next Steps
+
+After completing this module, you'll be ready to explore:
+
+* xref:storage:index.adoc[Storage Configuration] - Deep dive into storage options
+* xref:networking:index.adoc[Networking Configuration] - Network setup for VMs

--- a/modules/getting-started/pages/prerequisites.adoc
+++ b/modules/getting-started/pages/prerequisites.adoc
@@ -1,0 +1,120 @@
+= Prerequisites and Setup
+:navtitle: Prerequisites
+
+== Overview
+
+This page outlines the prerequisites and requirements for working with OpenShift Virtualization as described in this cookbook.
+
+== Cluster Requirements
+
+=== OpenShift Version
+
+* OpenShift 4.17 or later
+* OpenShift Virtualization operator installed and running
+
+=== Cluster Access
+
+You'll need appropriate access levels depending on the tasks you want to perform:
+
+* **Cluster Admin**: Required for operator installation, storage configuration, and network configuration
+* **Namespace Admin**: Sufficient for managing VMs within specific namespaces
+* **Developer**: Can create and manage VMs with appropriate RBAC permissions
+
+== Required CLI Tools
+
+=== OpenShift CLI (oc)
+
+The OpenShift command-line interface is essential for cluster interaction.
+
+Install from: link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI Documentation,window=_blank]
+
+Verify installation:
+[source,bash,role=execute]
+----
+oc version
+----
+
+=== Kubernetes CLI (kubectl)
+
+While `oc` is preferred, `kubectl` can also be used for many operations.
+
+Install from: link:https://kubernetes.io/docs/tasks/tools/[Kubernetes Documentation,window=_blank]
+
+Verify installation:
+[source,bash,role=execute]
+----
+kubectl version
+----
+
+=== Virtctl
+
+The virtctl tool is specifically designed for managing KubeVirt/OpenShift Virtualization resources.
+
+Install from: link:https://docs.openshift.com/container-platform/latest/virt/virt-using-the-cli-tools.html[Virtctl Documentation,window=_blank]
+
+Verify installation:
+[source,bash,role=execute]
+----
+virtctl version
+----
+
+== Optional Tools
+
+Depending on your workflow, you may also want:
+
+* **kustomize**: For managing Kubernetes configurations
+* **helm**: For deploying packaged applications
+* **ansible**: For automation and orchestration
+
+== Cluster Configuration
+
+=== Storage
+
+Ensure your cluster has:
+
+* At least one StorageClass configured
+* Sufficient storage capacity for VM disks
+* A storage provisioner that supports dynamic provisioning
+
+Check available storage classes:
+[source,bash,role=execute]
+----
+oc get storageclass
+----
+
+=== Network
+
+Verify network connectivity:
+
+* Cluster networking is functional
+* Pod network is accessible
+* External network access if required for your VMs
+
+== Verification
+
+Before proceeding with the tutorials, verify your setup:
+
+[source,bash,role=execute]
+----
+# Check cluster status
+oc get nodes
+
+# Verify OpenShift Virtualization operator
+oc get csv -n openshift-cnv
+
+# Check available VM templates
+oc get datasources -n openshift-virtualization-os-images
+----
+
+== Next Steps
+
+Once you have the prerequisites in place:
+
+* xref:virtctl-basics.adoc[Learn virtctl basics]
+* xref:storage-setup.adoc[Configure default storage]
+
+== See Also
+
+* link:https://docs.openshift.com/container-platform/latest/virt/about_virt/about-virt.html[OpenShift Virtualization Documentation,window=_blank]
+* link:https://kubevirt.io/[KubeVirt Project,window=_blank]
+

--- a/modules/getting-started/pages/storage-setup.adoc
+++ b/modules/getting-started/pages/storage-setup.adoc
@@ -1,0 +1,257 @@
+= Configuring Default Storage Class
+:navtitle: Storage Setup
+
+== Overview
+
+This tutorial provides a step-by-step guide on how to configure a default storage class for OpenShift Virtualization. Setting a default storage class ensures that virtual machines and data volumes automatically use the specified storage class when no storage class is explicitly specified, simplifying VM deployment and management.
+
+== Prerequisites
+
+To get started, you'll need the following:
+
+* **OpenShift Cluster**: An OpenShift cluster with OpenShift Virtualization installed
+* **Cluster Admin Access**: Access to the cluster with cluster-admin privileges
+* **Storage Classes**: At least one StorageClass configured in your cluster
+* **Storage Provisioner**: A storage provisioner that supports dynamic provisioning
+
+Versions tested:
+----
+OCP 4.19
+----
+
+== Step 1: View Available Storage Classes
+
+First, check which storage classes are already available in your cluster and identify if there's already a default storage class configured.
+
+[source,bash,role=execute]
+----
+oc get sc
+----
+
+This command will list all the storage classes, showing their names and provisioners. Look for any storage class that has `(default)` next to its name, which indicates it's currently set as the default.
+
+Example output showing no default storage class:
+----
+NAME                    PROVISIONER                             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+ceph-rbd-sc             rbd.csi.ceph.com                        Delete          Immediate              true                   2d
+hostpath-provisioner    kubevirt.io/hostpath-provisioner        Delete          WaitForFirstConsumer   false                  1d
+local-storage           kubernetes.io/no-provisioner            Delete          WaitForFirstConsumer   false                  1d
+----
+
+Example output showing an existing default storage class:
+----
+NAME                    PROVISIONER                             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+ceph-rbd-sc (default)   rbd.csi.ceph.com                        Delete          Immediate              true                   2d
+hostpath-provisioner    kubevirt.io/hostpath-provisioner        Delete          WaitForFirstConsumer   false                  1d
+local-storage           kubernetes.io/no-provisioner            Delete          WaitForFirstConsumer   false                  1d
+----
+
+Take note of:
+
+. The name of the storage class you want to set as the default
+. Whether there's already a default storage class configured
+
+== Step 2: Remove Existing Default (If Necessary)
+
+If another storage class was already set as the default, you'll need to remove that annotation first before setting a new one. A cluster can only have one default storage class.
+
+To remove the default annotation from a storage class:
+
+[source,bash,role=execute]
+----
+oc annotate sc <the-old-default-storage-class-name> storageclass.kubernetes.io/is-default-class-
+----
+
+NOTE: The hyphen at the end of the annotation key is what removes the annotation.
+
+== Step 3: Annotate the Storage Class
+
+Add an annotation to the storage class you've chosen. This annotation tells OpenShift that this particular storage class should be the default one.
+
+The annotation is: `storageclass.kubernetes.io/is-default-class: "true"`
+
+[source,bash,role=execute]
+----
+oc annotate sc <your-storage-class-name> storageclass.kubernetes.io/is-default-class="true"
+----
+
+For example, if your storage class is named `ceph-rbd-sc`:
+
+[source,bash,role=execute]
+----
+oc annotate sc ceph-rbd-sc storageclass.kubernetes.io/is-default-class="true"
+----
+
+== Step 4: Verify the Default Storage Class
+
+After applying the annotation, verify that the change has taken effect:
+
+[source,bash,role=execute]
+----
+oc get sc
+----
+
+Example output after setting the default:
+----
+NAME                    PROVISIONER                             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+ceph-rbd-sc (default)   rbd.csi.ceph.com                        Delete          Immediate              true                   2d
+hostpath-provisioner    kubevirt.io/hostpath-provisioner        Delete          WaitForFirstConsumer   false                  1d
+local-storage           kubernetes.io/no-provisioner            Delete          WaitForFirstConsumer   false                  1d
+----
+
+You should see `(default)` next to your chosen storage class name.
+
+== Step 5: Test the Default Storage Class
+
+Create a simple test to verify that the default storage class is working correctly. Create a PVC without specifying a storage class:
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-default-storage
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+EOF
+----
+
+Then verify that the PVC was created with the correct storage class:
+
+[source,bash,role=execute]
+----
+oc get pvc test-default-storage -o yaml | grep storageClassName
+----
+
+You should see that the PVC was automatically assigned to your default storage class.
+
+== Step 6: Deploy a VM Using Default Storage
+
+Now you can deploy a virtual machine that will automatically use the default storage class for its data volumes:
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: test-vm-default-storage
+  namespace: default
+spec:
+  running: true
+  dataVolumeTemplates:
+  - metadata:
+      name: test-vm-disk
+    spec:
+      pvc:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+      sourceRef:
+        kind: DataSource
+        name: fedora
+        namespace: openshift-virtualization-os-images
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: test-vm-default-storage
+    spec:
+      domain:
+        devices:
+          disks:
+          - name: datavolumedisk
+            disk:
+              bus: virtio
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 1
+      networks:
+      - name: default
+        pod: {}
+      volumes:
+      - name: datavolumedisk
+        dataVolume:
+          name: test-vm-disk
+EOF
+----
+
+== Troubleshooting
+
+=== Common Issues
+
+==== Multiple Default Storage Classes
+
+If you see multiple storage classes marked as default, remove the annotation from all but one:
+
+[source,bash,role=execute]
+----
+oc get sc -o custom-columns=NAME:.metadata.name,DEFAULT:.metadata.annotations.storageclass\.kubernetes\.io/is-default-class
+----
+
+==== Storage Class Not Found
+
+Ensure the storage class exists before trying to annotate it:
+
+[source,bash,role=execute]
+----
+oc get sc <storage-class-name>
+----
+
+==== Permission Denied
+
+Make sure you have cluster-admin privileges:
+
+[source,bash,role=execute]
+----
+oc auth can-i create storageclass --all-namespaces
+----
+
+=== Verification Commands
+
+Check all storage classes and their default status:
+
+[source,bash,role=execute]
+----
+oc get sc -o wide
+----
+
+View detailed information about a specific storage class:
+
+[source,bash,role=execute]
+----
+oc describe sc <storage-class-name>
+----
+
+List PVCs and their storage classes:
+
+[source,bash,role=execute]
+----
+oc get pvc --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,STORAGECLASS:.spec.storageClassName
+----
+
+== Best Practices
+
+. **Choose Appropriate Storage**: Select a storage class that provides the performance and features needed for your VMs (e.g., fast I/O, snapshots, encryption).
+
+. **Consider Workload Requirements**: Different workloads may require different storage characteristics. Consider using specific storage classes for critical workloads rather than relying on defaults.
+
+. **Monitor Storage Usage**: Regularly monitor storage usage and performance to ensure the default storage class meets your needs.
+
+. **Document Your Choice**: Document why you chose a particular storage class as the default for future reference and troubleshooting.
+
+== References
+
+=== OpenShift Documentation
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/storage/understanding-persistent-storage#persistent-storage-overview_storage-classes[OpenShift - Storage Classes,window=_blank]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/virtualization/virtual-machines/virt-storage-overview[OpenShift Virtualization - Storage,window=_blank]
+

--- a/modules/getting-started/pages/virtctl-basics.adoc
+++ b/modules/getting-started/pages/virtctl-basics.adoc
@@ -1,0 +1,61 @@
+= Basic usage of the virtctl command
+:navtitle: Virtctl Basics
+
+This tutorial will provide a brief overview of the virtctl command. This document is designed to quickly cover some of the basic usage of this incredibly useful tool for controlling your virtual machines on OpenShift, but for more in-depth information on this tool, see our link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.13/html/virtualization/virt-using-the-cli-tools[official documentation,window=_blank]
+
+At a basic level, we have virtctl fslist <your vm name> to list the file systems available
+
+[source,bash]
+----
+$ virtctl fslist my-vm
+----
+
+virtctl userlist <your vm name> for a list of logged-in users
+
+[source,bash]
+----
+$ virtctl userlist my-vm
+----
+
+and virtctl guestosinfo <your vm name> for information about the operating system.
+
+[source,bash]
+----
+$ virtctl guestosinfo my-vm
+----
+
+You can type virtctl start <your vm name> to start a VM
+
+[source,bash]
+----
+$ virtctl start my-vm
+----
+
+and virtctl stop <your vm> to stop a VM.
+
+[source,bash]
+----
+$ virtctl stop my-vm
+----
+
+This can also be used with --force to force a stop, but be aware this can mess up the data on the VM.
+
+To pause a VM, keeping the machine state in memory you can run virtctl pause vm <your vm name>, and unpause it with virtctl unpause vm <name>.
+
+**Note: these commands require you to specify that you're talking about a vm, and the others don't.**
+
+One of the more useful commands is virtctl scp. Just like a regular scp command, this lets you copy files to and from your virtual machines. To use scp, you'll need to make sure your virtual machine has an SSH key to allow connections.
+
+To copy a file locally to your virtual machine, use virtctl scp -i <ssh key> <file name> <user name>@<your name>.
+
+[source,bash]
+----
+$ virtctl scp -i key myLocalFile.txt user@my-vm:myVMFileLocation.txt
+----
+
+If you need a file off a VM, you just reverse the command - virtctl scp -i <ssh key> <user name>@<your name>:<file name> <destination directory>.
+
+[source,bash]
+----
+$ virtctl scp -i key user@my-vm:VMFile.txt ~/Documents/
+----

--- a/modules/manifests/nav.adoc
+++ b/modules/manifests/nav.adoc
@@ -1,0 +1,7 @@
+* xref:index.adoc[YAML Manifests Reference]
+** xref:operators.adoc[Operators]
+** xref:networking.adoc[Networking]
+** xref:storage.adoc[Storage]
+** xref:vms.adoc[Virtual Machines]
+** xref:security.adoc[Security]
+

--- a/modules/manifests/pages/index.adoc
+++ b/modules/manifests/pages/index.adoc
@@ -1,0 +1,232 @@
+= YAML Manifests Reference
+:navtitle: Manifests Reference
+
+== Overview
+
+This section provides a comprehensive library of ready-to-use YAML manifests for OpenShift Virtualization. These manifests cover operators, networking, storage, virtual machines, and security configurations.
+
+All manifests are organized by category and include descriptions, use cases, and prerequisites.
+
+== Manifest Categories
+
+xref:operators.adoc[Operators]::
+YAML manifests for deploying and configuring essential operators including OpenShift Virtualization (CNV), LVM Storage Operator, and NMState Operator.
+
+xref:networking.adoc[Networking]::
+Network configuration manifests including NADs (Network Attachment Definitions), localnet networks, VLAN configurations, Linux bridges, UDNs (User Defined Networks), and bonding.
+
+xref:storage.adoc[Storage]::
+Storage-related manifests for LVM configurations, PVCs, data volumes, hostpath provisioner, iSCSI, and NFS storage.
+
+xref:vms.adoc[Virtual Machines]::
+Complete VM manifest examples organized by OS type (Fedora, RHEL, Windows) with various cloud-init configurations and use cases.
+
+xref:security.adoc[Security]::
+Security configurations including network policies, RBAC (Role-Based Access Control), and SCCs (Security Context Constraints).
+
+== How to Use These Manifests
+
+=== Basic Usage
+
+. Copy the manifest you need
+. Customize values (namespaces, names, IP addresses, etc.)
+. Apply with `oc apply -f manifest.yaml`
+. Verify with appropriate `oc get` commands
+
+=== Customization Tips
+
+**Namespaces:**
+
+Always verify and update namespace values to match your environment:
+
+[source,bash,role=execute]
+----
+# Create namespace if it doesn't exist
+oc create namespace my-namespace
+
+# Apply manifest to specific namespace
+oc apply -f manifest.yaml -n my-namespace
+----
+
+**Names:**
+
+Update resource names to follow your naming conventions:
+
+[source,yaml]
+----
+metadata:
+  name: my-custom-name  # Update this
+  namespace: my-namespace  # Update this
+----
+
+**Network Configurations:**
+
+Update IP addresses, VLAN IDs, and network names to match your infrastructure:
+
+[source,yaml]
+----
+# Update VLAN ID
+vlanId: 100  # Change to your VLAN
+
+# Update IP ranges
+ipv4: 192.168.100.0/24  # Change to your subnet
+----
+
+=== Testing Manifests
+
+. Test in development environment first
+. Start with minimal configurations
+. Verify each component before proceeding
+. Check logs if issues occur
+
+== Manifest Organization
+
+The manifests are organized to align with the tutorials in this cookbook:
+
+**Getting Started:**
+
+* Operator subscriptions
+* Basic namespace creation
+* Default storage class configuration
+
+**Storage Configuration:**
+
+* LVM operator manifests
+* Storage class definitions
+* PVC and DataVolume templates
+
+**Networking Configuration:**
+
+* NAD definitions for localnet, VLAN, bridges
+* UDN configurations
+* NMState node network configurations
+
+**VM Configuration:**
+
+* VM templates with cloud-init
+* DataVolume templates
+* Various OS configurations (Fedora, RHEL, Windows)
+
+**Security:**
+
+* Network policies for VM isolation
+* RBAC for VM management
+* SCC configurations
+
+== Prerequisites
+
+Before using these manifests, ensure you have:
+
+* OpenShift 4.17+ cluster access
+* Appropriate permissions (cluster-admin for operators, namespace admin for resources)
+* Required operators installed (CNV, LVM, NMState as needed)
+* CLI tools: `oc`, `kubectl`
+
+== Related Tutorials
+
+Most manifests in this section are referenced by tutorials in other modules:
+
+* xref:getting-started:index.adoc[Getting Started] - Basic setup and prerequisites
+* xref:storage:index.adoc[Storage Configuration] - LVM and storage setup
+* xref:networking:index.adoc[Networking Configuration] - Network configuration tutorials
+
+== Validation
+
+After applying manifests, validate your configuration:
+
+[source,bash,role=execute]
+----
+# Check operator status
+oc get csv -n openshift-cnv
+oc get csv -n openshift-storage
+
+# Check network attachments
+oc get network-attachment-definition -A
+
+# Check storage classes
+oc get storageclass
+
+# Check VMs
+oc get vm,vmi -A
+
+# Check nodes
+oc get nodes
+----
+
+== Common Patterns
+
+=== Creating a Namespace
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vms-prod
+  labels:
+    environment: production
+----
+
+=== Creating a NAD (Network Attachment Definition)
+
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: localnet-vlan-100
+  namespace: default
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "type": "ovn-k8s-cni-overlay",
+      "topology": "localnet",
+      "netAttachDefName": "default/localnet-vlan-100",
+      "vlanID": 100
+    }
+----
+
+=== Creating a PVC
+
+[source,yaml]
+----
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vm-data-disk
+  namespace: vms-prod
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: lvms-vg1
+----
+
+== Best Practices
+
+. **Version Control**: Keep your manifests in Git for tracking changes
+. **Documentation**: Comment your customizations in the YAML
+. **Testing**: Always test in a non-production environment first
+. **Validation**: Use `oc apply --dry-run=client` to validate syntax
+. **Backups**: Keep backups of working configurations
+. **Secrets**: Never commit sensitive data to version control
+
+== Troubleshooting
+
+If a manifest fails to apply:
+
+. Check syntax: `oc apply --dry-run=client -f manifest.yaml`
+. Verify API version: `oc api-resources | grep <kind>`
+. Check permissions: `oc auth can-i create <resource>`
+. Review events: `oc get events -n <namespace> --sort-by='.lastTimestamp'`
+. Check logs: `oc logs <pod-name> -n <namespace>`
+
+== See Also
+
+* link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI Reference,window=_blank]
+* link:https://kubernetes.io/docs/reference/kubectl/[Kubectl Reference,window=_blank]
+* link:https://docs.openshift.com/container-platform/latest/virt/about_virt/about-virt.html[OpenShift Virtualization Documentation,window=_blank]
+

--- a/modules/manifests/pages/networking.adoc
+++ b/modules/manifests/pages/networking.adoc
@@ -1,0 +1,500 @@
+= Networking Manifests
+:navtitle: Networking
+
+== Overview
+
+This page provides Network Attachment Definition (NAD) manifests and network configuration examples for OpenShift Virtualization, organized by network topology type.
+
+== Network Topology Types
+
+OpenShift Virtualization supports several network topologies:
+
+* **Localnet**: Direct access to physical network via OVS bridge
+* **Layer2 UDN**: User Defined Networks with Layer 2 connectivity
+* **Overlay**: OVN overlay networks (cloud-like networking)
+* **Linux Bridges**: Traditional Linux bridge networking
+* **Bond Interfaces**: Network interface bonding for redundancy
+
+== Localnet Networks
+
+Localnet topology provides VMs with direct access to physical network infrastructure through the OVS (Open vSwitch) bridge.
+
+=== Localnet with VLAN Tagging
+
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: localnet-vlan-100
+  namespace: default
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "localnet-vlan-100",
+      "type": "ovn-k8s-cni-overlay",
+      "topology": "localnet",
+      "netAttachDefName": "default/localnet-vlan-100",
+      "vlanID": 100,
+      "subnets": "192.168.100.0/24",
+      "excludeSubnets": "192.168.100.1/32"
+    }
+----
+
+**Purpose:** Connects VMs to physical VLAN 100.
+
+**Key Fields:**
+
+* `topology: localnet` - Direct physical network access
+* `vlanID: 100` - VLAN tag (must match physical switch configuration)
+* `subnets` - IP range for the network
+* `excludeSubnets` - IPs to exclude (typically gateway)
+
+**Prerequisites:**
+
+* OVS bridge configured with physnet mapping
+* Physical switch port configured for VLAN trunking
+* xref:networking:ovs-bridge-verification.adoc[Troubleshooting OVS Bridge Creation for Localnet Networks]
+
+=== Localnet without VLAN (Native)
+
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: localnet-native
+  namespace: default
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "localnet-native",
+      "type": "ovn-k8s-cni-overlay",
+      "topology": "localnet",
+      "netAttachDefName": "default/localnet-native",
+      "subnets": "192.168.1.0/24",
+      "excludeSubnets": "192.168.1.1/32"
+    }
+----
+
+**When to use:** When VMs need access to untagged (native) VLAN on physical network.
+
+**Note:** No `vlanID` field means native/untagged VLAN.
+
+=== Localnet with Static IPAM
+
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: localnet-static-ipam
+  namespace: default
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "localnet-static",
+      "type": "ovn-k8s-cni-overlay",
+      "topology": "localnet",
+      "netAttachDefName": "default/localnet-static-ipam",
+      "subnets": "192.168.100.0/24",
+      "excludeSubnets": "192.168.100.1-192.168.100.50",
+      "ipam": {
+        "type": "static"
+      }
+    }
+----
+
+**When to use:** When VMs use cloud-init for static IP configuration rather than OVN-Kubernetes IPAM.
+
+**Note:** Use with cloud-init `networkData` to configure static IPs.
+
+=== Related Tutorials
+
+* xref:networking:localnet-secondary.adoc[Localnet Secondary Networks with CUDN]
+* xref:networking:localnet-vlan.adoc[Localnet Secondary Networks with VLAN using NAD]
+* xref:networking:ovs-bridge-verification.adoc[Troubleshooting OVS Bridge Creation for Localnet Networks]
+
+== User Defined Networks (UDN)
+
+UDNs allow creating custom primary networks for VMs, providing Layer 2 connectivity with isolated broadcast domains.
+
+=== Layer 2 UDN
+
+[source,yaml]
+----
+apiVersion: k8s.ovn.org/v1
+kind: UserDefinedNetwork
+metadata:
+  name: vm-layer2-network
+  namespace: vm-guests
+spec:
+  topology: Layer2
+  layer2:
+    role: Primary
+    subnets:
+      - "192.168.100.0/24"
+    mtu: 1400
+    ipamLifecycle: Persistent
+----
+
+**Purpose:** Creates a Layer 2 network for VM primary network attachment.
+
+**Key Fields:**
+
+* `topology: Layer2` - Layer 2 broadcast domain
+* `role: Primary` - Can be used as VM primary network
+* `subnets` - IP range for the network
+* `ipamLifecycle: Persistent` - IPs persist across VM reboots
+
+=== Layer 2 NAD for UDN
+
+After creating the UDN, create a NAD to reference it:
+
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: vm-layer2-nad
+  namespace: vm-guests
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "vm-layer2-network",
+      "type": "ovn-k8s-cni-overlay",
+      "topology": "layer2",
+      "role": "primary",
+      "netAttachDefName": "vm-guests/vm-layer2-nad",
+      "subnets": "192.168.100.0/24",
+      "allowPersistentIPs": true,
+      "layer2": {
+        "subnets": ["192.168.100.0/24"],
+        "joinSubnets": ["192.168.100.0/24"],
+        "mtu": 1400
+      }
+    }
+----
+
+**When to use:** When VMs need custom primary network separate from pod network.
+
+=== Related Tutorials
+
+* xref:networking:udn-primary-networks.adoc[Layer 2 Primary Networks with UDNs]
+
+== Linux Bridges
+
+Linux bridges provide traditional bridge networking for VMs on a per-node basis.
+
+=== Linux Bridge Node Configuration
+
+Use NMState to configure Linux bridge on nodes:
+
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: br-vlan100-policy
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  desiredState:
+    interfaces:
+      - name: br-vlan100
+        description: Linux bridge for VLAN 100
+        type: linux-bridge
+        state: up
+        ipv4:
+          enabled: false
+        bridge:
+          options:
+            stp:
+              enabled: false
+          port:
+            - name: ens224
+              vlan:
+                mode: access
+                tag: 100
+----
+
+**Purpose:** Creates Linux bridge attached to physical interface with VLAN 100.
+
+**Customization:**
+
+* `name: br-vlan100` - Bridge name
+* `name: ens224` - Physical interface (update to your interface)
+* `tag: 100` - VLAN tag
+
+=== Linux Bridge NAD
+
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bridge-vlan100
+  namespace: default
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "bridge-vlan100",
+      "type": "cnv-bridge",
+      "bridge": "br-vlan100",
+      "macspoofchk": true,
+      "ipam": {}
+    }
+----
+
+**Purpose:** NAD that references the Linux bridge for VM attachment.
+
+**When to use:** When per-node isolation is acceptable and OVS is not available.
+
+=== Related Tutorials
+
+* xref:networking:linux-bridges.adoc[Linux Bridges for VMs]
+
+== Overlay Networks
+
+OVN overlay networks provide cloud-like networking with automatic IPAM.
+
+=== Overlay Network with DHCP
+
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: overlay-dhcp
+  namespace: default
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "overlay-dhcp",
+      "type": "ovn-k8s-cni-overlay",
+      "topology": "layer2",
+      "subnets": "10.200.0.0/16",
+      "mtu": 1400,
+      "netAttachDefName": "default/overlay-dhcp",
+      "ipam": {
+        "type": "ovn-k8s-cni-ipam",
+        "provider": "ovn-kubernetes"
+      }
+    }
+----
+
+**Purpose:** Creates isolated overlay network with OVN-Kubernetes IPAM.
+
+**When to use:** For cloud-like isolated networks without physical network dependencies.
+
+**Benefits:**
+
+* No physical network configuration required
+* Automatic IPAM
+* Network isolation
+* Portable across nodes
+
+== Bond Interfaces
+
+Network bonding provides redundancy and increased bandwidth.
+
+=== Bond Interface Configuration
+
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: bond-config
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  desiredState:
+    interfaces:
+      - name: bond0
+        description: Active-backup bond
+        type: bond
+        state: up
+        ipv4:
+          enabled: false
+        link-aggregation:
+          mode: active-backup
+          options:
+            miimon: "100"
+          port:
+            - ens224
+            - ens256
+----
+
+**Purpose:** Creates active-backup bond interface for redundancy.
+
+**Bond Modes:**
+
+* `active-backup` - One active, others standby
+* `802.3ad` - LACP (requires switch support)
+* `balance-rr` - Round-robin
+* `balance-xor` - XOR hash-based
+
+== Cluster Network Physical Mapping
+
+For localnet topology, map logical network names to physical bridges:
+
+[source,bash,role=execute]
+----
+# This is typically configured via NMState NNCP
+# See operators manifest for OVS bridge mapping example
+oc get nncp ovs-br-mapping -o yaml
+----
+
+The mapping defines:
+
+* **Logical network name** (e.g., `physnet1`) - Used in NAD configurations
+* **Physical bridge** (e.g., `br-ex`) - OVS bridge name on nodes
+
+== Network Verification
+
+=== Verify NADs
+
+[source,bash,role=execute]
+----
+# List all NADs
+oc get network-attachment-definition -A
+
+# Describe specific NAD
+oc describe network-attachment-definition <nad-name> -n <namespace>
+
+# Check NAD in VM
+oc get vmi <vm-name> -n <namespace> -o jsonpath='{.spec.networks[*]}'
+----
+
+=== Verify OVS Configuration
+
+[source,bash,role=execute]
+----
+# Check OVS bridge mapping on node
+oc debug node/<node-name>
+chroot /host
+ovs-vsctl show
+ovs-vsctl get Open_vSwitch . external_ids:ovn-bridge-mappings
+----
+
+=== Test Network Connectivity
+
+[source,bash,role=execute]
+----
+# Get VM IP
+oc get vmi <vm-name> -n <namespace> -o jsonpath='{.status.interfaces[*].ipAddress}'
+
+# Test from another VM or pod
+ping <vm-ip>
+
+# Inside VM console
+virtctl console <vm-name> -n <namespace>
+ip addr show
+ip route show
+----
+
+== Common Network Patterns
+
+=== Single Network (Pod Network Only)
+
+[source,yaml]
+----
+spec:
+  template:
+    spec:
+      networks:
+        - name: default
+          pod: {}
+----
+
+**Use case:** Simple VMs, development, testing.
+
+=== Dual Network (Pod + Secondary)
+
+[source,yaml]
+----
+spec:
+  template:
+    spec:
+      networks:
+        - name: default
+          pod: {}
+        - name: vlan-network
+          multus:
+            networkName: localnet-vlan-100
+----
+
+**Use case:** Production VMs with management (pod) and data (VLAN) networks.
+
+=== Multiple Networks
+
+[source,yaml]
+----
+spec:
+  template:
+    spec:
+      networks:
+        - name: default
+          pod: {}
+        - name: data-network
+          multus:
+            networkName: localnet-vlan-100
+        - name: storage-network
+          multus:
+            networkName: localnet-vlan-200
+----
+
+**Use case:** Complex deployments with network segmentation.
+
+== Troubleshooting
+
+=== NAD Not Found
+
+[source,bash]
+----
+Error: NAD "localnet-vlan-100" not found in namespace "default"
+----
+
+**Solution:** Create NAD in same namespace as VM or use `namespace/nad-name` format.
+
+=== No Connectivity on Secondary Network
+
+**Check:**
+
+. NAD exists: `oc get nad -n <namespace>`
+. OVS bridge configured: `oc get nncp`
+. Physical switch configured for VLAN
+. Cloud-init network configuration correct
+
+=== VM Interface Not Getting IP
+
+**Check:**
+
+. IPAM configuration in NAD
+. Cloud-init logs: `/var/log/cloud-init.log`
+. Interface status: `ip addr show`
+. DHCP client running: `nmcli device status`
+
+== Summary
+
+Key network manifest types:
+
+* **Localnet NADs**: Direct physical network access
+* **UDN**: Custom primary networks for VMs
+* **Linux Bridge NADs**: Traditional bridge networking
+* **Overlay NADs**: Cloud-like isolated networks
+* **Bond configurations**: Network redundancy
+
+== See Also
+
+* xref:networking:index.adoc[Networking Configuration Overview]
+* xref:manifests:operators.adoc[NMState Operator Configuration]
+* xref:manifests:index.adoc[Manifests Reference Overview]
+

--- a/modules/manifests/pages/operators.adoc
+++ b/modules/manifests/pages/operators.adoc
@@ -1,0 +1,314 @@
+= Operator Manifests
+:navtitle: Operators
+
+== Overview
+
+This page provides YAML manifests for deploying and configuring essential operators for OpenShift Virtualization, including the LVM Storage Operator and NMState Operator.
+
+== Prerequisites
+
+* OpenShift 4.17+ cluster
+* Cluster administrator access
+* CLI tools: `oc`, `kubectl`
+
+== LVM Storage Operator
+
+The LVM Storage Operator provides local storage for OpenShift Virtualization using LVM (Logical Volume Manager).
+
+=== Namespace Creation
+
+First, create the required namespace:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-storage
+  labels:
+    openshift.io/cluster-monitoring: "true"
+----
+
+=== Operator Group
+
+Create an OperatorGroup to manage the LVM operator:
+
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-storage-operatorgroup
+  namespace: openshift-storage
+spec:
+  targetNamespaces:
+  - openshift-storage
+----
+
+**Purpose:** Defines the namespace scope for the LVM operator.
+
+**When to use:** Required before installing the LVM operator subscription.
+
+=== Subscription
+
+Subscribe to the LVM operator:
+
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: lvm-operator
+  namespace: openshift-storage
+spec:
+  channel: stable-4.19
+  name: lvm-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+----
+
+**Purpose:** Installs and manages the LVM Storage Operator.
+
+**When to use:** After creating namespace and OperatorGroup.
+
+**Note:** Update the `channel` field to match your OpenShift version.
+
+=== Apply LVM Operator Manifests
+
+[source,bash,role=execute]
+----
+# Create namespace
+oc apply -f namespace.yaml
+
+# Create OperatorGroup
+oc apply -f operator-group.yaml
+
+# Create Subscription
+oc apply -f subscription.yaml
+
+# Wait for operator to be ready
+oc wait --for=condition=Ready pod -l app.kubernetes.io/name=lvm-operator -n openshift-storage --timeout=300s
+
+# Verify installation
+oc get csv -n openshift-storage
+oc get pods -n openshift-storage
+----
+
+=== Related Tutorial
+
+For complete LVM operator setup including LVMCluster configuration, see:
+
+* xref:storage:lvm-operator.adoc[Installing LVM Storage Operator]
+* xref:storage:lvm-troubleshooting.adoc[Troubleshooting LVM Storage]
+
+== NMState Operator
+
+The NMState Operator manages node network configuration, essential for configuring OVS bridges and network mappings for OpenShift Virtualization.
+
+=== Installation
+
+The NMState operator is typically pre-installed with OpenShift Virtualization. Verify installation:
+
+[source,bash,role=execute]
+----
+# Check if NMState operator is installed
+oc get csv -n openshift-nmstate
+
+# Check NMState pods
+oc get pods -n openshift-nmstate
+----
+
+If not installed, install from OperatorHub:
+
+. Navigate to Operators > OperatorHub in OpenShift Console
+. Search for "Kubernetes NMState Operator"
+. Click Install
+. Select "stable" channel
+. Install in "openshift-nmstate" namespace
+
+=== OVS Bridge Mapping Configuration
+
+Configure OVS bridge mapping for localnet networks:
+
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: ovs-br-mapping
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  desiredState:
+    interfaces:
+      - name: ens224
+        description: Physical interface for OVS localnet
+        type: ethernet
+        state: up
+        ipv4:
+          enabled: false
+        ipv6:
+          enabled: false
+    ovs-db:
+      external_ids:
+        ovn-bridge-mappings: "physnet1:br-ex"
+        ovn-cms-options: "enable-chassis-as-gw"
+----
+
+**Purpose:** Maps physical network interface to OVS bridge for localnet topology.
+
+**When to use:** Required for localnet secondary networks and VLAN configurations.
+
+**Customization:**
+
+* `name: ens224` - Update to your physical interface name (find with `ip link show`)
+* `physnet1` - Logical network name (used in NAD configurations)
+* `br-ex` - OVS bridge name (typically `br-ex`)
+
+=== Verify OVS Bridge Configuration
+
+[source,bash,role=execute]
+----
+# Check NodeNetworkConfigurationPolicy status
+oc get nncp
+
+# Get detailed status
+oc describe nncp ovs-br-mapping
+
+# Verify on nodes (requires debug pod)
+oc debug node/<node-name>
+chroot /host
+ovs-vsctl show
+ovs-vsctl get Open_vSwitch . external_ids:ovn-bridge-mappings
+----
+
+=== Related Tutorials
+
+For network configuration using NMState, see:
+
+* xref:networking:ovs-bridge-verification.adoc[Troubleshooting OVS Bridge Creation for Localnet Networks]
+* xref:networking:localnet-secondary.adoc[Localnet Secondary Networks with CUDN]
+* xref:networking:localnet-vlan.adoc[Localnet Secondary Networks with VLAN using NAD]
+
+== OpenShift Virtualization Operator (CNV)
+
+The OpenShift Virtualization (Container Native Virtualization) operator is the foundation for running VMs on OpenShift.
+
+=== Installation
+
+Install from OperatorHub:
+
+. Navigate to Operators > OperatorHub in OpenShift Console
+. Search for "OpenShift Virtualization"
+. Click Install
+. Select "stable" channel
+. Install in "openshift-cnv" namespace
+. Wait for installation to complete
+
+=== Verify Installation
+
+[source,bash,role=execute]
+----
+# Check operator status
+oc get csv -n openshift-cnv
+
+# Check HyperConverged CR
+oc get hco -n openshift-cnv
+
+# Check pods
+oc get pods -n openshift-cnv
+
+# Check available VM images
+oc get datasource -n openshift-virtualization-os-images
+----
+
+=== HyperConverged Configuration
+
+The HyperConverged custom resource configures OpenShift Virtualization:
+
+[source,bash,role=execute]
+----
+# View current configuration
+oc get hco kubevirt-hyperconverged -n openshift-cnv -o yaml
+----
+
+Key configuration options:
+
+* Feature gates for experimental features
+* Network configuration defaults
+* Storage defaults
+* Live migration settings
+
+=== Related Information
+
+For complete setup and usage:
+
+* xref:getting-started:prerequisites.adoc[Prerequisites and Setup]
+* xref:getting-started:virtctl-basics.adoc[Virtctl Basics]
+
+== Operator Management
+
+=== Check Operator Status
+
+[source,bash,role=execute]
+----
+# List all operators
+oc get csv -A
+
+# Check specific operator
+oc get csv -n openshift-cnv
+oc get csv -n openshift-storage
+oc get csv -n openshift-nmstate
+
+# Check operator pods
+oc get pods -n openshift-cnv
+oc get pods -n openshift-storage
+oc get pods -n openshift-nmstate
+----
+
+=== Update Operators
+
+Operators with `installPlanApproval: Automatic` update automatically. For manual approval:
+
+[source,bash,role=execute]
+----
+# List pending install plans
+oc get installplan -n openshift-storage
+
+# Approve install plan
+oc patch installplan <install-plan-name> -n openshift-storage \
+  --type merge --patch '{"spec":{"approved":true}}'
+----
+
+=== Troubleshooting Operators
+
+[source,bash,role=execute]
+----
+# Check operator events
+oc get events -n openshift-storage --sort-by='.lastTimestamp'
+
+# Check operator logs
+oc logs -n openshift-storage deployment/lvm-operator-controller-manager
+
+# Check ClusterServiceVersion
+oc describe csv -n openshift-storage
+----
+
+== Summary
+
+Key operator manifests covered:
+
+* **LVM Storage Operator**: Provides local storage using LVM
+* **NMState Operator**: Manages node network configuration
+* **OpenShift Virtualization**: Core virtualization platform
+
+All operators work together to provide a complete virtualization platform with networking and storage capabilities.
+
+== See Also
+
+* xref:storage:lvm-operator.adoc[LVM Operator Installation Guide]
+* xref:networking:ovs-bridge-verification.adoc[Troubleshooting OVS Bridge Creation for Localnet Networks]
+* xref:index.adoc[Manifests Reference Overview]
+* link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm/olm-understanding-olm.html[Operator Lifecycle Manager,window=_blank]
+

--- a/modules/manifests/pages/security.adoc
+++ b/modules/manifests/pages/security.adoc
@@ -1,0 +1,643 @@
+= Security Manifests
+:navtitle: Security
+
+== Overview
+
+This page provides security-related YAML manifests for OpenShift Virtualization, including Network Policies, RBAC (Role-Based Access Control), and SCCs (Security Context Constraints).
+
+== Network Policies
+
+Network Policies control traffic flow between pods and VMs in OpenShift.
+
+=== Allow All Traffic to VMs
+
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-to-vms
+  namespace: vms-prod
+spec:
+  podSelector:
+    matchLabels:
+      kubevirt.io/domain: ""
+  policyTypes:
+    - Ingress
+  ingress:
+    - {}
+----
+
+**Purpose:** Allows all inbound traffic to VMs in namespace.
+
+**When to use:** Development environments, testing, non-production.
+
+NOTE: This is permissive. Use restrictive policies in production.
+
+=== Allow Traffic from Specific Namespace
+
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-app-namespace
+  namespace: vms-prod
+spec:
+  podSelector:
+    matchLabels:
+      kubevirt.io/domain: ""
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: app-frontend
+----
+
+**Purpose:** Allows traffic only from pods in `app-frontend` namespace.
+
+**When to use:** Isolating VMs to specific application namespaces.
+
+=== Allow Specific Ports
+
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-web-traffic
+  namespace: vms-prod
+spec:
+  podSelector:
+    matchLabels:
+      app: webserver
+      kubevirt.io/domain: ""
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 443
+----
+
+**Purpose:** Allows HTTP/HTTPS traffic to web server VMs.
+
+**When to use:** Web-facing VMs requiring restricted access.
+
+=== Deny All Traffic (Default Deny)
+
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: vms-prod
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+----
+
+**Purpose:** Denies all traffic unless explicitly allowed by other policies.
+
+**When to use:** Security-first approach, explicitly allow only required traffic.
+
+NOTE: Add this first, then add specific allow policies as needed.
+
+=== Allow DNS and SSH
+
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-and-ssh
+  namespace: vms-prod
+spec:
+  podSelector:
+    matchLabels:
+      kubevirt.io/domain: ""
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 22
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 53
+    - to:
+        - podSelector: {}
+----
+
+**Purpose:** Allows SSH access and DNS resolution.
+
+**Key Features:**
+
+* SSH (port 22) ingress from any namespace
+* DNS (port 53) egress to DNS namespace
+* Allows egress to pods in same namespace
+
+== RBAC (Role-Based Access Control)
+
+RBAC controls who can perform actions on OpenShift resources.
+
+=== VM Viewer Role
+
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vm-viewer
+  namespace: vms-prod
+rules:
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - virtualmachineinstances
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+----
+
+**Purpose:** Read-only access to VMs in namespace.
+
+**Permissions:**
+
+* View VMs and VMIs
+* View related pods and services
+* No modify permissions
+
+=== VM Operator Role
+
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vm-operator
+  namespace: vms-prod
+rules:
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - virtualmachineinstances
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - update
+      - patch
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/start
+      - virtualmachines/stop
+      - virtualmachines/restart
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - create
+  - apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - datavolumes
+    verbs:
+      - get
+      - list
+      - create
+----
+
+**Purpose:** Full VM lifecycle management within namespace.
+
+**Permissions:**
+
+* Create, modify, delete VMs
+* Start, stop, restart VMs
+* Create PVCs and DataVolumes
+* View resources
+
+=== VM Admin Role
+
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vm-admin
+  namespace: vms-prod
+rules:
+  - apiGroups:
+      - ""
+      - kubevirt.io
+      - cdi.kubevirt.io
+      - k8s.cni.cncf.io
+    resources:
+      - "*"
+    verbs:
+      - "*"
+----
+
+**Purpose:** Full administrative access to all VM-related resources in namespace.
+
+NOTE: Very permissive. Use sparingly and only for administrators.
+
+=== Role Binding
+
+Bind roles to users or groups:
+
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vm-operators-binding
+  namespace: vms-prod
+subjects:
+  - kind: User
+    name: alice@example.com
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: vm-operators
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: vm-operator
+  apiGroup: rbac.authorization.k8s.io
+----
+
+**Purpose:** Grants `vm-operator` role to user Alice and group vm-operators.
+
+=== ClusterRole for VM Management Across Namespaces
+
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-vm-operator
+rules:
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - virtualmachineinstances
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - update
+      - patch
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/start
+      - virtualmachines/stop
+      - virtualmachines/restart
+    verbs:
+      - update
+----
+
+**Purpose:** VM management permissions across all namespaces.
+
+**Binding:**
+
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-vm-operators-binding
+subjects:
+  - kind: Group
+    name: platform-team
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-vm-operator
+  apiGroup: rbac.authorization.k8s.io
+----
+
+== Security Context Constraints (SCCs)
+
+SCCs control pod security policies in OpenShift.
+
+=== VM Privileged SCC
+
+OpenShift Virtualization VMs require specific SCCs. The operator automatically creates required SCCs.
+
+Check VM-related SCCs:
+
+[source,bash,role=execute]
+----
+# List SCCs
+oc get scc | grep kubevirt
+
+# View specific SCC
+oc describe scc kubevirt-controller
+----
+
+**Pre-configured SCCs:**
+
+* `kubevirt-controller` - For virt-controller
+* `kubevirt-handler` - For virt-handler
+* `hostmount-anyuid` - For VM launcher pods
+
+NOTE: Generally, you don't need to create custom SCCs for VMs. The operator handles this.
+
+=== Custom SCC for Specific VM Workloads
+
+If needed, create custom SCC:
+
+[source,yaml]
+----
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: vm-custom-scc
+allowPrivilegedContainer: false
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+----
+
+**When to use:** Custom security requirements beyond default VM SCCs.
+
+== Service Accounts
+
+Service accounts for VM management automation.
+
+=== VM Management Service Account
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vm-manager
+  namespace: vms-prod
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vm-manager-binding
+  namespace: vms-prod
+subjects:
+  - kind: ServiceAccount
+    name: vm-manager
+    namespace: vms-prod
+roleRef:
+  kind: Role
+  name: vm-operator
+  apiGroup: rbac.authorization.k8s.io
+----
+
+**Purpose:** Service account for automated VM management.
+
+**Use cases:**
+
+* CI/CD pipelines
+* Automation scripts
+* Monitoring tools
+
+== Security Best Practices
+
+. **Principle of Least Privilege**
++
+Grant minimum necessary permissions.
+
+. **Network Segmentation**
++
+Use Network Policies to isolate VM workloads.
+
+. **Regular Audits**
++
+Review RBAC assignments periodically.
+
+. **Service Account Management**
++
+Use service accounts for automation, not user credentials.
+
+. **Default Deny**
++
+Start with deny-all Network Policy, then allow specific traffic.
+
+. **Namespace Isolation**
++
+Use separate namespaces for different environments.
+
+. **Secrets Management**
++
+Don't hardcode passwords in cloud-init userData.
+
+. **SSH Key Authentication**
++
+Use SSH keys instead of passwords for VM access.
+
+== Verification
+
+=== Check Network Policies
+
+[source,bash,role=execute]
+----
+# List Network Policies
+oc get networkpolicy -n vms-prod
+
+# Describe specific policy
+oc describe networkpolicy <policy-name> -n vms-prod
+
+# Check if policy applies to specific pod
+oc get pod <virt-launcher-pod> -n vms-prod --show-labels
+----
+
+=== Check RBAC Permissions
+
+[source,bash,role=execute]
+----
+# Check what user can do
+oc auth can-i create vm -n vms-prod --as=alice@example.com
+
+# Check all permissions for user
+oc auth can-i --list -n vms-prod --as=alice@example.com
+
+# View role bindings
+oc get rolebinding -n vms-prod
+oc describe rolebinding <binding-name> -n vms-prod
+----
+
+=== Check Service Accounts
+
+[source,bash,role=execute]
+----
+# List service accounts
+oc get serviceaccount -n vms-prod
+
+# Get service account token
+oc sa get-token vm-manager -n vms-prod
+
+# Check service account permissions
+oc auth can-i --list --as=system:serviceaccount:vms-prod:vm-manager -n vms-prod
+----
+
+=== Check SCCs
+
+[source,bash,role=execute]
+----
+# List SCCs
+oc get scc
+
+# Check which SCC is used by pod
+oc get pod <virt-launcher-pod> -n vms-prod -o yaml | grep "openshift.io/scc"
+
+# Describe SCC
+oc describe scc kubevirt-controller
+----
+
+== Troubleshooting
+
+=== Permission Denied Errors
+
+**Error:**
+
+```
+Error from server (Forbidden): User "alice@example.com" cannot create resource "virtualmachines"
+```
+
+**Solution:**
+
+[source,bash,role=execute]
+----
+# Check user permissions
+oc auth can-i create vm -n vms-prod --as=alice@example.com
+
+# Check role bindings
+oc get rolebinding -n vms-prod
+
+# Add role binding if missing
+oc create rolebinding alice-vm-operator \
+  --role=vm-operator \
+  --user=alice@example.com \
+  -n vms-prod
+----
+
+=== Network Policy Blocking Traffic
+
+**Symptoms:** VM cannot communicate despite correct network configuration.
+
+**Check:**
+
+[source,bash,role=execute]
+----
+# List network policies
+oc get networkpolicy -n vms-prod
+
+# Check if policy matches VM pod
+oc get vmi <vm-name> -n vms-prod -o yaml | grep labels -A 5
+
+# Temporarily remove policy to test
+oc delete networkpolicy <policy-name> -n vms-prod
+----
+
+=== SCC Issues
+
+**Error:**
+
+```
+unable to validate against any security context constraint
+```
+
+**Solution:**
+
+[source,bash,role=execute]
+----
+# Check available SCCs
+oc get scc | grep kubevirt
+
+# Verify operator installation
+oc get csv -n openshift-cnv
+
+# Check virt-controller logs
+oc logs -n openshift-cnv deployment/virt-controller
+----
+
+== Summary
+
+Key security manifest types:
+
+* **Network Policies**: Control traffic flow between VMs and pods
+* **Roles/RoleBindings**: Control who can manage VMs
+* **ClusterRoles**: Cluster-wide permissions
+* **Service Accounts**: For automation and integration
+* **SCCs**: Pod security policies (mostly automatic)
+
+Security approach:
+
+. Start with least privilege
+. Use Network Policies for isolation
+. Grant RBAC permissions as needed
+. Use service accounts for automation
+. Regular security audits
+
+== See Also
+
+* xref:index.adoc[Manifests Reference Overview]
+* link:https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html[OpenShift RBAC,window=_blank]
+* link:https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html[Security Context Constraints,window=_blank]
+* link:https://docs.openshift.com/container-platform/latest/networking/network_policy/about-network-policy.html[Network Policies,window=_blank]
+

--- a/modules/manifests/pages/storage.adoc
+++ b/modules/manifests/pages/storage.adoc
@@ -1,0 +1,538 @@
+= Storage Manifests
+:navtitle: Storage
+
+== Overview
+
+This page provides storage-related YAML manifests for OpenShift Virtualization, including LVMCluster configurations, StorageClass definitions, PVCs, and DataVolumes.
+
+== LVM Storage
+
+=== LVMCluster Configuration
+
+After installing the LVM operator, create an LVMCluster to configure local storage:
+
+[source,yaml]
+----
+apiVersion: lvm.topolvm.io/v1alpha1
+kind: LVMCluster
+metadata:
+  name: lvmcluster
+  namespace: openshift-storage
+spec:
+  storage:
+    deviceClasses:
+      - name: vg1
+        default: true
+        deviceSelector:
+          paths:
+            - /dev/sdb
+            - /dev/sdc
+        thinPoolConfig:
+          name: thin-pool-1
+          sizePercent: 90
+          overprovisionRatio: 10
+        nodeSelector:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: node-role.kubernetes.io/worker
+                  operator: In
+                  values:
+                    - ""
+----
+
+**Purpose:** Configures LVM storage on worker nodes using specified devices.
+
+**Key Fields:**
+
+* `deviceClasses[].name` - Storage class name suffix
+* `default: true` - Makes this the default device class
+* `paths` - Block devices to use (must be empty, no partitions)
+* `sizePercent: 90` - Percentage of VG for thin pool
+* `overprovisionRatio: 10` - Thin provisioning ratio
+
+**Prerequisites:**
+
+* LVM operator installed
+* Block devices available on nodes
+* Devices must be empty (no existing partitions)
+
+**Find Available Devices:**
+
+[source,bash,role=execute]
+----
+# List block devices on node
+oc debug node/<node-name>
+chroot /host
+lsblk
+----
+
+=== Verify LVMCluster
+
+[source,bash,role=execute]
+----
+# Check LVMCluster status
+oc get lvmcluster -n openshift-storage
+
+# Check LVMVolumeGroup status
+oc get lvmvolumegroup -n openshift-storage
+
+# Check created StorageClass
+oc get storageclass | grep lvms
+
+# Check topolvm pods
+oc get pods -n openshift-storage -l app.kubernetes.io/name=topolvm-node
+----
+
+=== Related Tutorial
+
+* xref:storage:lvm-operator.adoc[Installing LVM Storage Operator]
+* xref:storage:lvm-troubleshooting.adoc[Troubleshooting LVM Storage]
+
+== StorageClass
+
+=== LVM-based StorageClass
+
+The LVM operator automatically creates StorageClass:
+
+[source,yaml]
+----
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: lvms-vg1
+provisioner: topolvm.io
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+  topolvm.io/device-class: vg1
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+----
+
+**Key Features:**
+
+* `volumeBindingMode: WaitForFirstConsumer` - Delays binding until pod scheduled
+* `allowVolumeExpansion: true` - Allows PVC resizing
+* `reclaimPolicy: Delete` - Deletes PV when PVC deleted
+
+=== Set Default StorageClass
+
+[source,bash,role=execute]
+----
+# Remove existing default
+oc patch storageclass <old-default> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+
+# Set new default
+oc patch storageclass lvms-vg1 -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+
+# Verify
+oc get storageclass
+----
+
+**Related Tutorial:**
+
+* xref:getting-started:storage-setup.adoc[Configuring Default Storage Class]
+
+== PersistentVolumeClaim (PVC)
+
+=== Basic PVC
+
+[source,yaml]
+----
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vm-disk
+  namespace: vms-prod
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: lvms-vg1
+----
+
+**Purpose:** Requests storage for VM disk.
+
+**Access Modes:**
+
+* `ReadWriteOnce` - Single node read-write (typical for VM disks)
+* `ReadWriteMany` - Multi-node read-write (requires special storage)
+* `ReadOnlyMany` - Multi-node read-only
+
+=== PVC with Volume Mode Block
+
+[source,yaml]
+----
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vm-block-disk
+  namespace: vms-prod
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: lvms-vg1
+----
+
+**When to use:** For raw block devices without filesystem.
+
+== DataVolume
+
+DataVolumes are OpenShift Virtualization's preferred way to provision storage for VMs.
+
+=== DataVolume from Container Image
+
+[source,yaml]
+----
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: fedora-dv
+  namespace: vms-prod
+spec:
+  source:
+    registry:
+      url: docker://quay.io/containerdisks/fedora:latest
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 30Gi
+    storageClassName: lvms-vg1
+----
+
+**Purpose:** Creates VM disk from container disk image.
+
+=== DataVolume from HTTP Source
+
+[source,yaml]
+----
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: rhel9-dv
+  namespace: vms-prod
+spec:
+  source:
+    http:
+      url: https://example.com/rhel9.qcow2
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 40Gi
+    storageClassName: lvms-vg1
+----
+
+**Purpose:** Creates VM disk from qcow2 image via HTTP.
+
+=== DataVolume from DataSource
+
+[source,yaml]
+----
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: fedora-from-datasource
+  namespace: vms-prod
+spec:
+  sourceRef:
+    kind: DataSource
+    name: fedora
+    namespace: openshift-virtualization-os-images
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 30Gi
+    storageClassName: lvms-vg1
+----
+
+**Purpose:** Creates VM disk from pre-existing DataSource.
+
+**Benefits:**
+
+* Uses cluster-provided OS images
+* Fast provisioning
+* Automatically updated images
+
+=== DataVolume Clone
+
+[source,yaml]
+----
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: vm-disk-clone
+  namespace: vms-prod
+spec:
+  source:
+    pvc:
+      namespace: vms-prod
+      name: original-vm-disk
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 50Gi
+    storageClassName: lvms-vg1
+----
+
+**Purpose:** Clones existing PVC to create new VM disk.
+
+**Use cases:**
+
+* VM templates
+* Quick VM deployment
+* Testing scenarios
+
+== DataVolume Templates
+
+DataVolumeTemplates are embedded in VM definitions for automatic provisioning.
+
+=== VM with DataVolumeTemplate
+
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora-vm
+  namespace: vms-prod
+spec:
+  dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: fedora-vm-disk
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: fedora
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources:
+            requests:
+              storage: 30Gi
+          storageClassName: lvms-vg1
+  runStrategy: Always
+  template:
+    spec:
+      domain:
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+        resources:
+          requests:
+            memory: 4Gi
+      volumes:
+        - dataVolume:
+            name: fedora-vm-disk
+          name: rootdisk
+----
+
+**Benefits:**
+
+* Automatic DataVolume creation with VM
+* Simplified VM manifests
+* Lifecycle tied to VM
+
+== Additional Disks
+
+=== Add Data Disk to Running VM
+
+Create PVC:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vm-data-disk
+  namespace: vms-prod
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: lvms-vg1
+----
+
+Add to VM:
+
+[source,bash,role=execute]
+----
+# Add disk to VM
+virtctl addvolume <vm-name> -n vms-prod \
+  --volume-name=data-disk \
+  --persist \
+  --serial=data001
+
+# Verify
+oc get vm <vm-name> -n vms-prod -o yaml | grep -A 5 "volumes:"
+----
+
+== Storage Verification
+
+=== Check Storage Resources
+
+[source,bash,role=execute]
+----
+# Check StorageClass
+oc get storageclass
+
+# Check PVCs
+oc get pvc -A
+
+# Check PVs
+oc get pv
+
+# Check DataVolumes
+oc get datavolume -A
+
+# Check DataSources
+oc get datasource -n openshift-virtualization-os-images
+----
+
+=== Check Storage Usage
+
+[source,bash,role=execute]
+----
+# Check LVM volume usage
+oc get lvmvolumegroup -n openshift-storage -o yaml
+
+# Check node storage
+oc debug node/<node-name>
+chroot /host
+lvs
+vgs
+pvs
+----
+
+=== DataVolume Status
+
+[source,bash,role=execute]
+----
+# Check DataVolume status
+oc get dv <dv-name> -n <namespace>
+
+# Watch DataVolume provisioning
+oc get dv <dv-name> -n <namespace> -w
+
+# Check DataVolume events
+oc describe dv <dv-name> -n <namespace>
+----
+
+== Storage Best Practices
+
+. **Use DataVolumes** for VM disks instead of direct PVCs
+. **Set Default StorageClass** appropriate for your environment
+. **Size Appropriately** - Consider thin provisioning ratios
+. **Monitor Storage** usage to avoid exhaustion
+. **Use DataSources** for common OS images
+. **Test Provisioning** in development before production
+. **Plan Capacity** based on overprovision ratio
+
+== Troubleshooting
+
+=== DataVolume Stuck in Pending
+
+**Check:**
+
+[source,bash,role=execute]
+----
+# Check DataVolume status
+oc describe dv <dv-name> -n <namespace>
+
+# Check CDI operator logs
+oc logs -n openshift-cnv deployment/cdi-operator
+
+# Check importer pod
+oc get pods -n <namespace> | grep importer
+oc logs <importer-pod> -n <namespace>
+----
+
+**Common Causes:**
+
+* No default StorageClass
+* Insufficient storage capacity
+* Network issues downloading image
+* Invalid source URL
+
+=== PVC Not Binding
+
+**Check:**
+
+[source,bash,role=execute]
+----
+# Check PVC status
+oc describe pvc <pvc-name> -n <namespace>
+
+# Check StorageClass
+oc get storageclass <storage-class>
+
+# Check provisioner pods
+oc get pods -n openshift-storage
+----
+
+**Common Causes:**
+
+* StorageClass doesn't exist
+* No available storage on nodes
+* Provisioner not running
+* Volume binding mode waiting for consumer
+
+=== LVM Volume Full
+
+**Check:**
+
+[source,bash,role=execute]
+----
+# Check LVMVolumeGroup
+oc get lvmvolumegroup -n openshift-storage -o yaml
+
+# Check node LVM status
+oc debug node/<node-name>
+chroot /host
+vgs
+lvs
+----
+
+**Solutions:**
+
+* Delete unused PVCs
+* Add more disks to deviceClass
+* Reduce overprovision ratio
+* Expand thin pool
+
+== Summary
+
+Key storage manifest types:
+
+* **LVMCluster**: Configures LVM storage operator
+* **StorageClass**: Defines storage provisioner
+* **PVC**: Requests storage volume
+* **DataVolume**: Provisions storage for VMs
+* **DataVolumeTemplate**: Embedded in VM for automatic provisioning
+
+== See Also
+
+* xref:storage:lvm-operator.adoc[LVM Operator Installation]
+* xref:storage:lvm-troubleshooting.adoc[LVM Troubleshooting]
+* xref:getting-started:storage-setup.adoc[Storage Setup]
+* xref:index.adoc[Manifests Reference Overview]
+* link:https://docs.openshift.com/container-platform/latest/virt/storage/virt-storage-config-overview.html[OpenShift Virtualization Storage,window=_blank]
+

--- a/modules/manifests/pages/vms.adoc
+++ b/modules/manifests/pages/vms.adoc
@@ -1,0 +1,698 @@
+= Virtual Machine Manifests
+:navtitle: Virtual Machines
+
+== Overview
+
+This page provides complete VM manifest examples for different operating systems and use cases, including cloud-init configurations and network attachments.
+
+== Basic VM Structure
+
+A typical VM manifest includes:
+
+* `dataVolumeTemplates` - Storage provisioning
+* `runStrategy` - VM lifecycle management  
+* `template.spec.domain` - VM hardware configuration
+* `template.spec.networks` - Network attachments
+* `template.spec.volumes` - Volume attachments
+
+== Fedora VM Examples
+
+=== Basic Fedora VM with DHCP
+
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora-basic
+  namespace: vms-prod
+spec:
+  dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: fedora-basic-disk
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: fedora
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources:
+            requests:
+              storage: 30Gi
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: fedora-basic
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - masquerade: {}
+              name: default
+          rng: {}
+        machine:
+          type: pc-q35-rhel9.4.0
+        memory:
+          guest: 4Gi
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - dataVolume:
+            name: fedora-basic-disk
+          name: rootdisk
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: fedora123
+              chpasswd: { expire: False }
+              ssh_pwauth: True
+          name: cloudinitdisk
+----
+
+**Key Components:**
+
+* Uses Fedora DataSource from cluster
+* 2 vCPUs, 4Gi memory
+* Masquerade interface (default pod network)
+* Cloud-init with basic user configuration
+
+=== Fedora VM with Multiple Networks
+
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora-multi-network
+  namespace: vms-prod
+spec:
+  dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: fedora-multi-network-disk
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: fedora
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources:
+            requests:
+              storage: 30Gi
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: fedora-multi-network
+    spec:
+      domain:
+        cpu:
+          cores: 4
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - masquerade: {}
+              name: default
+            - bridge: {}
+              name: data-network
+          rng: {}
+        machine:
+          type: pc-q35-rhel9.4.0
+        memory:
+          guest: 8Gi
+      networks:
+        - name: default
+          pod: {}
+        - name: data-network
+          multus:
+            networkName: localnet-vlan-100
+      volumes:
+        - dataVolume:
+            name: fedora-multi-network-disk
+          name: rootdisk
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: fedora123
+              chpasswd: { expire: False }
+              ssh_pwauth: True
+            networkData: |-
+              version: 2
+              ethernets:
+                enp1s0:
+                  dhcp4: true
+                enp2s0:
+                  dhcp4: false
+                  dhcp6: false
+                  addresses:
+                    - 192.168.100.50/24
+          name: cloudinitdisk
+----
+
+**Key Features:**
+
+* Two network interfaces (pod network + VLAN)
+* Static IP on secondary interface via cloud-init
+* 4 vCPUs, 8Gi memory for higher workloads
+
+**Related Tutorial:**
+
+* xref:networking:localnet-vlan.adoc[Localnet Secondary Networks with VLAN using NAD]
+
+== RHEL VM Examples
+
+=== RHEL 9 VM
+
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: rhel9-vm
+  namespace: vms-prod
+spec:
+  dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: rhel9-vm-disk
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: rhel9
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources:
+            requests:
+              storage: 40Gi
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: rhel9-vm
+        app: database
+        environment: production
+    spec:
+      domain:
+        cpu:
+          cores: 4
+          sockets: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - masquerade: {}
+              name: default
+          rng: {}
+        machine:
+          type: pc-q35-rhel9.4.0
+        memory:
+          guest: 16Gi
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - dataVolume:
+            name: rhel9-vm-disk
+          name: rootdisk
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: changeme
+              chpasswd: { expire: True }
+              ssh_pwauth: True
+              packages:
+                - vim
+                - git
+              runcmd:
+                - systemctl enable --now cockpit.socket
+          name: cloudinitdisk
+----
+
+**Key Features:**
+
+* RHEL 9 DataSource
+* Labels for organization (app, environment)
+* Package installation via cloud-init
+* Cockpit enabled for web management
+
+=== RHEL with Additional Data Disk
+
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: rhel9-with-data-disk
+  namespace: vms-prod
+spec:
+  dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: rhel9-with-data-disk-root
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: rhel9
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources:
+            requests:
+              storage: 40Gi
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: rhel9-with-data-disk-data
+      spec:
+        source:
+          blank: {}
+        storage:
+          resources:
+            requests:
+              storage: 100Gi
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: rhel9-with-data-disk
+    spec:
+      domain:
+        cpu:
+          cores: 4
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+            - disk:
+                bus: virtio
+              name: datadisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - masquerade: {}
+              name: default
+          rng: {}
+        machine:
+          type: pc-q35-rhel9.4.0
+        memory:
+          guest: 16Gi
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - dataVolume:
+            name: rhel9-with-data-disk-root
+          name: rootdisk
+        - dataVolume:
+            name: rhel9-with-data-disk-data
+          name: datadisk
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: changeme
+              chpasswd: { expire: True }
+              ssh_pwauth: True
+          name: cloudinitdisk
+----
+
+**Key Features:**
+
+* Two DataVolumes - root and data disks
+* Blank data disk for application data
+* Separate storage management
+
+== Windows VM Example
+
+=== Windows Server 2022
+
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: windows-2022
+  namespace: vms-prod
+spec:
+  dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: windows-2022-disk
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: win2k22
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources:
+            requests:
+              storage: 60Gi
+  runStrategy: RerunOnFailure
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: windows-2022
+    spec:
+      domain:
+        cpu:
+          cores: 4
+          sockets: 1
+          threads: 1
+        devices:
+          disks:
+            - disk:
+                bus: sata
+              name: rootdisk
+            - cdrom:
+                bus: sata
+              name: windows-guest-tools
+          interfaces:
+            - masquerade: {}
+              model: e1000e
+              name: default
+          inputs:
+            - bus: usb
+              name: tablet
+              type: tablet
+          rng: {}
+        features:
+          acpi: {}
+          apic: {}
+          hyperv:
+            relaxed: {}
+            spinlocks:
+              spinlocks: 8191
+            vapic: {}
+        machine:
+          type: pc-q35-rhel9.4.0
+        memory:
+          guest: 16Gi
+        resources:
+          requests:
+            memory: 16Gi
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - dataVolume:
+            name: windows-2022-disk
+          name: rootdisk
+        - containerDisk:
+            image: registry.redhat.io/container-native-virtualization/virtio-win-rhel9
+          name: windows-guest-tools
+----
+
+**Key Features for Windows:**
+
+* `bus: sata` for Windows compatibility
+* `model: e1000e` network adapter
+* Hyper-V enlightenments for better performance
+* VirtIO drivers via container disk
+* USB tablet for mouse input
+
+**Note:** Windows VMs require valid licenses and proper guest tools installation.
+
+== VM Lifecycle Management
+
+=== Run Strategies
+
+**Always:**
+[source,yaml]
+----
+spec:
+  runStrategy: Always
+----
+VM should always be running. Automatically restarts if stopped.
+
+**RerunOnFailure:**
+[source,yaml]
+----
+spec:
+  runStrategy: RerunOnFailure
+----
+VM restarts only if it fails. Normal shutdown keeps it stopped.
+
+**Manual:**
+[source,yaml]
+----
+spec:
+  runStrategy: Manual
+----
+VM lifecycle managed manually via virtctl or API.
+
+**Halted:**
+[source,yaml]
+----
+spec:
+  runStrategy: Halted
+----
+VM should be stopped. Running VM will be shut down.
+
+=== Start/Stop VMs
+
+[source,bash,role=execute]
+----
+# Start VM
+virtctl start <vm-name> -n <namespace>
+
+# Stop VM (graceful)
+virtctl stop <vm-name> -n <namespace>
+
+# Restart VM
+virtctl restart <vm-name> -n <namespace>
+
+# Pause VM
+virtctl pause vm <vm-name> -n <namespace>
+
+# Unpause VM
+virtctl unpause vm <vm-name> -n <namespace>
+----
+
+== VM Resource Management
+
+=== CPU Configuration
+
+[source,yaml]
+----
+spec:
+  template:
+    spec:
+      domain:
+        cpu:
+          cores: 4
+          sockets: 2
+          threads: 1
+          dedicatedCpuPlacement: false
+          model: host-passthrough
+----
+
+**CPU Models:**
+
+* `host-passthrough` - Pass through host CPU features
+* `host-model` - Similar to host, filtered for migration
+* Specific models - e.g., `Skylake-Client`
+
+=== Memory Configuration
+
+[source,yaml]
+----
+spec:
+  template:
+    spec:
+      domain:
+        memory:
+          guest: 16Gi
+          hugepages:
+            pageSize: 2Mi
+        resources:
+          requests:
+            memory: 16Gi
+          limits:
+            memory: 16Gi
+----
+
+**Memory Options:**
+
+* `guest` - Memory visible to guest OS
+* `hugepages` - Use huge pages for better performance
+* `requests/limits` - Kubernetes resource management
+
+== VM Verification
+
+=== Check VM Status
+
+[source,bash,role=execute]
+----
+# List VMs
+oc get vm -n <namespace>
+
+# List running VMs (VMIs)
+oc get vmi -n <namespace>
+
+# Get VM details
+oc describe vm <vm-name> -n <namespace>
+
+# Get VMI details  
+oc describe vmi <vm-name> -n <namespace>
+
+# Check VM events
+oc get events -n <namespace> --field-selector involvedObject.name=<vm-name>
+----
+
+=== Access VM Console
+
+[source,bash,role=execute]
+----
+# Text console
+virtctl console <vm-name> -n <namespace>
+
+# VNC console (requires port-forward)
+virtctl vnc <vm-name> -n <namespace>
+
+# RDP for Windows (requires service)
+virtctl rdp <vm-name> -n <namespace>
+----
+
+=== Check VM Network
+
+[source,bash,role=execute]
+----
+# Get VM IP addresses
+oc get vmi <vm-name> -n <namespace> -o jsonpath='{.status.interfaces[*].ipAddress}'
+
+# Get VM interface details
+oc get vmi <vm-name> -n <namespace> -o jsonpath='{.status.interfaces[*]}'
+----
+
+== VM Best Practices
+
+. **Use DataSources** for standard OS images
+. **Set Appropriate Resources** based on workload
+. **Use Labels** for organization and selection
+. **Configure Cloud-init** for initialization
+. **Test in Development** before production
+. **Monitor Resource Usage** to right-size VMs
+. **Use runStrategy** appropriately for workload type
+. **Enable Guest Agent** for better integration
+
+== Troubleshooting
+
+=== VM Won't Start
+
+**Check:**
+
+[source,bash,role=execute]
+----
+# Check VM status
+oc get vm <vm-name> -n <namespace> -o yaml
+
+# Check events
+oc get events -n <namespace> --field-selector involvedObject.name=<vm-name>
+
+# Check virt-launcher pod
+oc get pods -n <namespace> | grep virt-launcher
+oc logs <virt-launcher-pod> -n <namespace>
+----
+
+**Common Causes:**
+
+* Insufficient resources on nodes
+* DataVolume not ready
+* Invalid configuration
+* Storage issues
+
+=== VM Running But No Network
+
+**Check:**
+
+[source,bash,role=execute]
+----
+# Access console
+virtctl console <vm-name> -n <namespace>
+
+# Inside VM
+ip addr show
+ip route show
+cat /etc/resolv.conf
+----
+
+**Common Causes:**
+
+* Cloud-init network configuration error
+* NAD not found
+* Interface naming mismatch
+* DHCP not working
+
+=== VM Performance Issues
+
+**Check:**
+
+[source,bash,role=execute]
+----
+# Check resource usage
+oc adm top pod <virt-launcher-pod> -n <namespace>
+
+# Inside VM
+top
+free -h
+df -h
+----
+
+**Solutions:**
+
+* Increase CPU/memory
+* Use VirtIO drivers
+* Enable huge pages
+* Check disk I/O
+
+== Summary
+
+Key VM manifest components:
+
+* **DataVolumeTemplates**: Automatic storage provisioning
+* **runStrategy**: Lifecycle management
+* **domain**: Hardware configuration (CPU, memory, devices)
+* **networks**: Network attachments
+* **cloud-init**: Initialization configuration
+
+== See Also
+
+* xref:getting-started:virtctl-basics.adoc[Virtctl Basics]
+* xref:networking.adoc[Network Configuration]
+* xref:storage.adoc[Storage Configuration]
+* xref:index.adoc[Manifests Reference Overview]
+* link:https://docs.openshift.com/container-platform/latest/virt/virtual_machines/creating_vms_custom/virt-creating-vms-by-using-yaml.html[Creating VMs with YAML,window=_blank]
+

--- a/modules/networking/nav.adoc
+++ b/modules/networking/nav.adoc
@@ -1,0 +1,7 @@
+* xref:index.adoc[Networking Configuration]
+** xref:udn-primary-networks.adoc[UDN Primary Networks]
+** xref:localnet-secondary.adoc[Localnet Secondary Networks with CUDN]
+** xref:localnet-vlan.adoc[Localnet Secondary Networks with VLAN using NAD]
+** xref:cudn-localnet-vlan.adoc[Localnet VLAN with CUDN]
+** xref:linux-bridges.adoc[Linux Bridges]
+** xref:ovs-bridge-verification.adoc[Troubleshooting OVS Bridge Creation for Localnet Networks]

--- a/modules/networking/pages/cudn-localnet-vlan.adoc
+++ b/modules/networking/pages/cudn-localnet-vlan.adoc
@@ -1,0 +1,507 @@
+= Configuring Localnet Secondary Networks with VLAN using ClusterUserDefinedNetwork in OpenShift Virtualization
+:navtitle: Localnet VLAN with CUDN
+
+This tutorial demonstrates how to configure localnet secondary networks with VLAN tagging using ClusterUserDefinedNetwork (CUDN) in OpenShift Virtualization. This approach provides direct access to physical network infrastructure with VLAN segmentation across multiple namespaces, enabling VMs to communicate with specific VLAN-tagged networks while maintaining pod network connectivity. CUDN offers centralized management and cross-namespace network availability, making it ideal for enterprise environments requiring consistent VLAN-based network infrastructure.
+
+== Prerequisites
+
+* **NMState Operator**: Must be installed and running in the cluster
+* **NMState CR**: The nmstate instance must be created after the operator is running
+* **Worker nodes**: The bridge mapping will be applied to worker nodes
+* **VLAN Infrastructure**: Physical network infrastructure must support VLAN tagging
+* **Switch Configuration**: Physical switch ports connected to OpenShift worker nodes must be configured in **trunk mode** to handle multiple VLAN-tagged traffic streams
+
+Versions tested:
+----
+OCP 4.19
+----
+
+== Network Configuration Requirements
+
+=== Physical Switch Configuration: TRUNK MODE
+
+The physical switch ports connected to OpenShift worker nodes **must be configured in trunk mode** for localnet VLAN configuration to work properly:
+
+* **Trunk mode**: Allows switch ports to carry traffic for multiple VLANs
+* **VLAN tagging**: Each VLAN is identified by its unique VLAN ID (e.g., 100, 200, 300)
+* **Multiple networks**: Essential for supporting multiple VLAN-based secondary networks
+
+== Step 1: Create VM Namespaces
+
+Create namespaces for VMs that will use the localnet secondary network with VLAN configuration. CUDN allows the same network to be available across multiple namespaces.
+
+[source,bash]
+----
+# Create first namespace
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vm-guests-vlan-prod
+EOF
+
+# Create second namespace
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vm-guests-vlan-dev
+EOF
+----
+
+== Step 2: Create Custom OVS Bridge on Extra NIC
+
+First, create a custom OVS bridge on an additional physical network interface (NIC) to isolate VLAN traffic from the primary cluster network.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: br-vlan-creation
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ''
+  desiredState:
+    interfaces:
+    - name: enp11s0f0np0  # Replace with your physical interface name
+      type: ethernet
+      state: up
+      ipv4:
+        enabled: false
+      ipv6:
+        enabled: false
+      description: "Physical interface for VLAN localnet"
+    - name: br-vlan
+      type: ovs-bridge
+      state: up
+      bridge:
+        port:
+        - name: enp11s0f0np0
+      description: "OVS bridge for VLAN traffic"
+EOF
+----
+
+NOTE: Replace `enp11s0f0np0` with the name of your extra physical interface. You can find available interfaces by running:
+
+[source,bash]
+----
+oc debug node/<node-name> -- ip link show
+----
+
+Verify the bridge creation:
+
+[source,bash]
+----
+oc get nncp br-vlan-creation
+# Expected output: STATUS: Available
+----
+
+== Step 3: Configure Bridge Mapping
+
+Configure the bridge mapping that connects the logical network interface name `localnet-vlan` to the `br-vlan` OVS bridge on worker nodes. This mapping tells OVN-Kubernetes which physical bridge interface handles localnet traffic with VLAN support.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: cudn-localnet-vlan-bridge-mapping
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ''  
+  desiredState:
+    ovn:
+      bridge-mappings:
+      - localnet: localnet-vlan
+        bridge: br-vlan
+        state: present
+EOF
+----
+
+== Step 4: Create ClusterUserDefinedNetwork with VLAN
+
+Create a ClusterUserDefinedNetwork that configures localnet topology with VLAN tagging for secondary network connectivity across multiple namespaces.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: cudn-localnet-vlan-100
+spec:
+  namespaceSelector: 
+    matchExpressions: 
+    - key: kubernetes.io/metadata.name
+      operator: In 
+      values: ["vm-guests-vlan-prod", "vm-guests-vlan-dev"]
+  network:
+    topology: Localnet 
+    localnet:
+      role: Secondary 
+      physicalNetworkName: localnet-vlan
+      vlanID: 100
+      ipam:
+        mode: Disabled
+EOF
+----
+
+**Configuration Details**:
+
+* `vlanID: 100`: Specifies VLAN tag 100 for network segmentation
+* `physicalNetworkName`: References the logical network interface name from bridge mapping (`localnet-vlan`)
+* `role: Secondary`: Defines this as a secondary network (VMs keep pod network as primary)
+* `namespaceSelector`: Defines which namespaces can use this network
+* **IPAM Disabled**: IP addresses must be configured via cloud-init (static) or external DHCP server
+
+== Step 5: Deploy VM with VLAN Network Connectivity and Static IP
+
+Create a VM in one of the configured namespaces that connects to both the pod network and the VLAN-tagged localnet secondary network.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora-cudn-vlan-vm
+  namespace: vm-guests-vlan-prod
+  labels:
+    app: fedora-cudn-vlan-vm
+spec:
+  runStrategy: Always
+  dataVolumeTemplates:
+  - metadata:
+      name: fedora-cudn-vlan-volume
+    spec:
+      pvc:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 33Gi
+      sourceRef:
+        kind: DataSource
+        name: fedora
+        namespace: openshift-virtualization-os-images
+  template:
+    metadata:
+      labels:
+        app: fedora-cudn-vlan-vm
+    spec:
+      domain:
+        devices:
+          disks:
+          - name: datavolumedisk
+            disk:
+              bus: virtio
+          - name: cloudinitdisk
+            disk:
+              bus: virtio
+          interfaces:
+          - name: default
+            bridge: {}
+          - name: cudn_vlan_network
+            bridge: {}
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 1
+      networks:
+      - name: default
+        pod: {}
+      - name: cudn_vlan_network
+        multus:
+          networkName: cudn-localnet-vlan-100
+      volumes:
+      - name: datavolumedisk
+        dataVolume:
+          name: fedora-cudn-vlan-volume
+      - name: cloudinitdisk
+        cloudInitNoCloud:
+          networkData: |
+            version: 2
+            ethernets:
+              enp2s0:
+                addresses: ["192.168.100.10/24"]
+          userData: |
+            #cloud-config
+            user: fedora
+            password: fedora
+            chpasswd: { expire: False }
+            packages:
+            - python3
+            - tcpdump
+            - net-tools
+            write_files:
+            - path: /root/index.html
+              content: |
+                <h1>Welcome to OpenShift Virtualization CUDN VLAN Network!</h1>
+                <p>VLAN ID: 100</p>
+                <p>Static IP: 192.168.100.10/24</p>
+                <p>Network: CUDN Localnet</p>
+                <p>Namespace: vm-guests-vlan-prod</p>
+              permissions: '0644'
+            runcmd:
+            - nohup python3 -m http.server 8080 --directory /root > /dev/null 2>&1 &
+EOF
+----
+
+== Step 6: Deploy VM in Second Namespace
+
+Demonstrate cross-namespace network availability by creating a VM in the second namespace using the same CUDN with a different static IP.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora-cudn-vlan-vm-dev
+  namespace: vm-guests-vlan-dev
+  labels:
+    app: fedora-cudn-vlan-vm-dev
+spec:
+  runStrategy: Always
+  dataVolumeTemplates:
+  - metadata:
+      name: fedora-cudn-vlan-volume-dev
+    spec:
+      pvc:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 33Gi
+      sourceRef:
+        kind: DataSource
+        name: fedora
+        namespace: openshift-virtualization-os-images
+  template:
+    metadata:
+      labels:
+        app: fedora-cudn-vlan-vm-dev
+    spec:
+      domain:
+        devices:
+          disks:
+          - name: datavolumedisk
+            disk:
+              bus: virtio
+          - name: cloudinitdisk
+            disk:
+              bus: virtio
+          interfaces:
+          - name: default
+            bridge: {}
+          - name: cudn_vlan_network
+            bridge: {}
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 1
+      networks:
+      - name: default
+        pod: {}
+      - name: cudn_vlan_network
+        multus:
+          networkName: cudn-localnet-vlan-100
+      volumes:
+      - name: datavolumedisk
+        dataVolume:
+          name: fedora-cudn-vlan-volume-dev
+      - name: cloudinitdisk
+        cloudInitNoCloud:
+          networkData: |
+            version: 2
+            ethernets:
+              enp2s0:
+                addresses: ["192.168.100.20/24"]
+          userData: |
+            #cloud-config
+            user: fedora
+            password: fedora
+            chpasswd: { expire: False }
+            packages:
+            - python3
+            - tcpdump
+            - net-tools
+            write_files:
+            - path: /root/index.html
+              content: |
+                <h1>Welcome to OpenShift Virtualization CUDN VLAN Network!</h1>
+                <p>VLAN ID: 100</p>
+                <p>Static IP: 192.168.100.20/24</p>
+                <p>Network: CUDN Localnet</p>
+                <p>Namespace: vm-guests-vlan-dev</p>
+              permissions: '0644'
+            runcmd:
+            - nohup python3 -m http.server 8080 --directory /root > /dev/null 2>&1 &
+EOF
+----
+
+== Step 7: Verify VLAN Network Connectivity
+
+Access the VM consoles to verify dual network connectivity with VLAN configuration across namespaces.
+
+[source,bash]
+----
+# Check VMs in production namespace
+oc get vm -n vm-guests-vlan-prod
+oc get vmi -n vm-guests-vlan-prod
+
+# Check VMs in development namespace
+oc get vm -n vm-guests-vlan-dev
+oc get vmi -n vm-guests-vlan-dev
+
+# Access production VM console (credentials: fedora/fedora via cloud-init)
+virtctl console -n vm-guests-vlan-prod fedora-cudn-vlan-vm
+
+# Access development VM console (credentials: fedora/fedora via cloud-init)
+virtctl console -n vm-guests-vlan-dev fedora-cudn-vlan-vm-dev
+----
+
+Inside each VM console, verify the VLAN network configuration:
+
+[source,bash]
+----
+# Check network interfaces - primary (pod network) and secondary (VLAN network)
+ip addr show
+
+# Check routes
+ip route show
+
+# Expected output example (primary network via DHCP):
+default via 10.128.0.1 dev enp1s0 proto dhcp src 10.128.0.174 metric 100 
+
+# Test external connectivity
+ping 8.8.8.8
+
+# Verify the web service is running
+curl localhost:8080
+
+# Verify static IP assignment on VLAN interface
+ip addr show enp2s0
+# Expected: inet 192.168.100.10/24 (prod) or 192.168.100.20/24 (dev)
+
+# Test VLAN interface connectivity between VMs
+# From production VM (192.168.100.10) ping development VM:
+ping 192.168.100.20
+
+# Verify VLAN tagging (if tcpdump is available)
+# This will show VLAN-tagged traffic on the secondary interface
+sudo tcpdump -i enp2s0 -nn vlan 100
+----
+
+== Step 8: Test Cross-Namespace Connectivity
+
+Verify that VMs in different namespaces can communicate over the shared CUDN VLAN network:
+
+[source,bash]
+----
+# From production VM (192.168.100.10), test connectivity to development VM
+ping 192.168.100.20
+
+# Test web service connectivity between namespaces
+curl 192.168.100.20:8080
+
+# From development VM (192.168.100.20), test connectivity to production VM
+ping 192.168.100.10
+curl 192.168.100.10:8080
+----
+
+== Troubleshooting
+
+For comprehensive OVS bridge and bridge mapping troubleshooting, including CUDN-specific verification steps, see the xref:ovs-bridge-verification.adoc#_clusteruserdefinednetwork_cudn_verification[OVS Bridge Verification Troubleshooting Guide].
+
+=== Common Issues
+
+==== VLAN Traffic Not Reaching VM
+
+* Verify physical switch configuration supports VLAN tagging
+* Check bridge mapping configuration on worker nodes
+* Ensure VLAN ID matches network infrastructure
+* Verify custom OVS bridge (`br-vlan`) is created: `oc get nncp br-vlan-creation`
+* Confirm physical interface is attached to bridge
+
+==== IP Address Assignment Issues
+
+* Verify static IP is configured correctly in cloud-init networkData
+* Check that the interface name matches (enp2s0 for second interface)
+* Verify cloud-init logs inside the VM: `cat /var/log/cloud-init.log`
+
+==== Network Connectivity Problems
+
+* Check that the physical network supports the configured VLAN
+* Test connectivity from physical network to VLAN subnet
+* Verify physical switch port is in trunk mode
+
+==== Cross-Namespace Issues
+
+* Verify namespace selector in CUDN configuration
+* Check that both namespaces are listed in the values array
+* Confirm NADs are auto-created in target namespaces
+
+==== CUDN-Specific Issues
+
+* Verify `physicalNetworkName` in CUDN matches bridge mapping logical name (`localnet-vlan`)
+* Check CUDN created NADs in selected namespaces: `oc get network-attachment-definitions -A | grep cudn-localnet-vlan-100`
+* Verify IPAM mode is set correctly (`Disabled` for static IPs via cloud-init)
+
+=== Verification Commands
+
+[source,bash]
+----
+# Check ClusterUserDefinedNetwork status
+oc get clusteruserdefinednetwork
+
+# Verify bridge mapping on worker nodes
+oc get nncp cudn-localnet-vlan-bridge-mapping -o yaml
+
+# Check VM network status in both namespaces
+oc get vmi -n vm-guests-vlan-prod -o yaml | grep -A 10 networks
+oc get vmi -n vm-guests-vlan-dev -o yaml | grep -A 10 networks
+
+# View OVN-Kubernetes logs for troubleshooting
+oc logs -n openshift-ovn-kubernetes -l app=ovnkube-node
+
+# Check CUDN network attachment across namespaces
+oc get network-attachment-definitions -A | grep cudn-localnet-vlan-100
+----
+
+== CUDN vs NetworkAttachmentDefinition Comparison
+
+|===
+| Feature | CUDN | NetworkAttachmentDefinition
+
+| **Scope**
+| Cluster-wide, multi-namespace
+| Namespace-specific
+
+| **Management**
+| Centralized configuration
+| Per-namespace configuration
+
+| **VLAN Support**
+| Native vlanID parameter
+| Native vlanID parameter
+
+| **IP Management**
+| Static/Disabled modes
+| Static/DHCP via IPAM
+
+| **Use Case**
+| Enterprise, consistent networks
+| Application-specific networks
+|===
+
+== References
+
+=== OpenShift Documentation
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/multiple_networks/understanding-multiple-networks[OpenShift - Understanding Multiple Networks,window=_blank]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/virtualization/networking#virt-creating-secondary-localnet-cudn_virt-connecting-vm-to-secondary-cudn[ClusterUserDefinedNetwork Configuration,window=_blank]
+

--- a/modules/networking/pages/index.adoc
+++ b/modules/networking/pages/index.adoc
@@ -1,0 +1,90 @@
+= Networking Configuration
+:navtitle: Networking
+
+== Overview
+
+This module covers comprehensive networking configuration for OpenShift Virtualization, including User Defined Networks (UDN), localnet topologies, VLANs, and Linux bridges. Proper network configuration is essential for integrating virtual machines with existing infrastructure and enabling communication between VMs and external systems.
+
+== What You'll Learn
+
+In this section, you will learn:
+
+* How to configure Layer 2 primary networks using User Defined Networks (UDN)
+* How to set up localnet secondary networks for external connectivity
+* How to configure VLAN tagging for network segregation
+* How to use Linux bridges for VM networking
+* How to verify OVS bridge configurations
+* Network topology patterns and use cases
+
+== Network Topology Options
+
+OpenShift Virtualization supports several network topology options:
+
+* **User Defined Networks (UDN)**: Custom Layer 2 networks with namespace isolation
+* **Localnet**: Direct access to physical network infrastructure
+* **Linux Bridges**: Traditional bridge networking for VMs
+* **OVN-Kubernetes Overlay**: Cluster default networking with pod connectivity
+
+== Prerequisites
+
+Before proceeding with the tutorials in this section, ensure you have:
+
+* OpenShift 4.19+ cluster with OpenShift Virtualization installed
+* NMState operator installed for physical network configuration
+* Understanding of basic networking concepts (subnets, VLANs, bridges)
+* Cluster admin access for network configuration
+
+== Sections
+
+xref:udn-primary-networks.adoc[Configuring Layer 2 Primary Networks with UDNs]::
+Configure Layer 2 primary networks using UDNs for namespace isolation.
+
+xref:localnet-secondary.adoc[Configuring Localnet Secondary Networks with ClusterUserDefinedNetwork]::
+Set up localnet topology for external network connectivity using ClusterUserDefinedNetwork.
+
+xref:localnet-vlan.adoc[Configuring Localnet Secondary Networks with VLAN using NetworkAttachmentDefinition]::
+Configure VLAN tagging with localnet networks using NetworkAttachmentDefinition.
+
+xref:cudn-localnet-vlan.adoc[Configuring Localnet Secondary Networks with VLAN using ClusterUserDefinedNetwork]::
+Configure VLAN tagging with localnet networks using ClusterUserDefinedNetwork for cross-namespace availability.
+
+xref:linux-bridges.adoc[Configuring Linux Bridges for VMs]::
+Traditional Linux bridge networking for VMs.
+
+xref:ovs-bridge-verification.adoc[Troubleshooting OVS Bridge Creation for Localnet Networks]::
+Verify and troubleshoot OVS bridge configurations.
+
+== Network Architecture Considerations
+
+=== Primary vs Secondary Networks
+
+* **Primary Networks**: Replace the pod network, complete network control
+* **Secondary Networks**: Add additional interfaces while keeping pod network
+
+=== IPAM Options
+
+* **OVN-Kubernetes IPAM**: Automatic IP allocation from defined subnets
+* **External DHCP**: Use existing DHCP servers
+* **Cloud-init**: Static IP configuration in VM images
+* **Disabled**: Manual IP configuration after deployment
+
+=== Physical Network Integration
+
+For localnet and Linux bridge topologies:
+
+* Requires physical network interface access on worker nodes
+* May need VLAN trunk configuration on physical switches
+* Bridge mappings connect logical network names to physical interfaces
+
+== Next Steps
+
+After completing this module, you'll be ready to:
+
+* Deploy production VMs with appropriate network topologies
+* Troubleshoot network connectivity issues
+
+== See Also
+
+* link:https://docs.openshift.com/container-platform/latest/virt/vm_networking/virt-about-vm-networking.html[OpenShift Virtualization Networking,window=_blank]
+* link:https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html[About OVN-Kubernetes,window=_blank]
+* link:https://kubevirt.io/user-guide/user_workloads/interfaces_and_networks/[KubeVirt Networking Documentation,window=_blank]

--- a/modules/networking/pages/linux-bridges.adoc
+++ b/modules/networking/pages/linux-bridges.adoc
@@ -1,0 +1,460 @@
+== Adding a Bridge as a Secondary Network Adapter
+
+This quick-guide describes how to add a secondary Linux bridge adapter to a VM.
+A Linux bridge acts as a network switch between pods running on the same node/host machine.
+Optionally, a bridge interface can be linked to a physical host interface.
+Doing this enables connections to external networks, which includes other pods/VMs running on other nodes/hosts.
+
+NOTE: A Linux bridge network attachment definition (NAD) is the simplest way to connect VM(s) to a VLAN.
+
+NOTE: This guide assumes that VMs have already been created in OpenShift Virtualization prior to being modified. Parts of this guide will require a namespace to be setup for the VMs which are being attached to a Linux bridge network.
+
+The process is broken down into the following steps:
+
+* <<install_nmstate_operator,Install NMState Operator>> onto the cluster.
+** <<nmstate_operator_gui_procedure,OpenShift console procedure for NMState Operator>>
+* <<create_linux_bridge_nncp,Create a Node Network Configuration Policy (NNCP) object>> to define the Linux bridge.
+** <<create_nncp_prereqs,Prerequisites for creating a NNCP object>>
+** <<create_nncp_cli_procedure,CLI procedure to create a NNCP object>>
+** <<create_nncp_gui_procedure,OpenShift console procedure to create a NNCP object>>
+* <<create_net_attach_def, Create a Network Attachment Definition (NAD)>> to provide Layer 2 networking to pods/VMs.
+** <<create_nad_prereqs,Prerequisites for creating a NAD>>
+** <<create_nad_cli_procedure,CLI procedure to create a NAD object>>
+** <<create_nad_gui_procedure,OpenShift console procedure to create a NAD object>>
+* <<configure_vm_nic, Configure the VM network interface connection (NIC)>> to connect the VM to the Linux bridge network.
+** <<vm_nic_prereqs,Prerequisites for configuring the VM NIC>>
+** <<vm_nic_gui_prcoedure,OpenShift console procedure to configure the VM NIC>>
+** <<vm_nic_cli_procedure,CLI procedure to configure the VM NIC>>
+
+=== Install the Kubernetes NMState Operator [[install_nmstate_operator]]
+This operator is required to configure the Node Network Configuration Policy (NNCP) objects used to create new bridge network adapters on each node.
+The NNCP actually creates the bridge interface on all (or specific) nodes/hosts in the cluster, which of course can be filtered using labels.
+The bridge interface must exist on the nodes/hosts that the VMs are running on, before you can attach a secondary NIC to a pod/VM.
+
+==== Procedure using the OpenShift console: [[nmstate_operator_gui_procedure]]
+Login to the OpenShift admin console as any user with cluster-admin privileges (such as the default `kubeadmin` account).
+
+On the navigation menu (left side), expand *Operators* then select *OperatorHub*.
+
+Locate and select the *Kubernetes NMState Operator* from the grid. Use the search box to filter the operator listings by name.
+
+Click *Install* to view the installation page, then click *Install* (accepting the defaults).
+
+When the operator installation completes, select *View Operator*.
+
+Under the Provided APIs list, click to *Create instance* of an NMState custom resource (CR).
+
+Ensure the CR is named `nmstate` and click *Create*.
+
+Wait until the web console displays the `Web console update is available` pop up message, and click *Refresh web console* on the bottom of the pop up (or wait a few moments and refresh).
+
+NOTE: On later versions of OpenShift, you may instead be logged out of the OpenShift console automatically, and you must then re-authenticate.
+
+From the navigation menu, expand *Networking* and check for the *NodeNetworkConfigurationPolicy* and *NodeNetworkState* items.
+These should both exist before proceeding with <<create_linux_bridge_nncp,creating  NodeNetworkConfigurationPolicy (NNCP)>>.
+
+==== Procedure using the CLI: [[nmstate_operator_cli_procedure]]
+Before proceeding, authenticate to your OpenShift cluster's API as a cluster-admin.
+
+Create the `openshift-nmstate` namespace:
+
+----
+oc create namespace openshift-nmstate
+----
+
+Using your favorite text editor, create the following Subscription object by copy/pasting the following yaml into a new buffer:
+
+----
+apiGroup: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: nmstate-operator
+  namespace: openshift-nmstate
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: kubernetes-nmstate-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+----
+
+Save the file as `k8s-nmstate-operator.subscription.yaml`, then create the subscription on the cluster:
+
+----
+oc create -f k8s-nmstate-operator.subscription.yaml -n openshift-nmstate
+----
+
+Wait until the operator has finished deploying. To check the current installation state, fetch the ClusterServiceVersion (`csv`) and check the install phase (last column):
+
+----
+oc get csv -n openshift-nmstate
+NAME                                              DISPLAY                       VERSION               REPLACES                                          PHASE
+kubernetes-nmstate-operator.4.18.0-202509101149   Kubernetes NMState Operator   4.18.0-202509101149   kubernetes-nmstate-operator.4.18.0-202508271223   Succeeded
+----
+
+Once the operator has finished installing, create the `nmstate` object. Once again, in your favorite text editor, paste the following yaml:
+
+----
+apiVersion: nmstate.io/v1
+kind: NMState
+metadata:
+  name: nmstate
+spec: {}
+----
+
+NOTE: `nmstate` objects are cluster scoped, so a namespace is not required. Only one `nmstate` (also named `nmstate`) should exist on the cluster.
+
+The `nmstate` object will trigger the NMState operator to install the `NodeNetworkConfigurationPolicy` and `NodeNetworkState` APIs (CRDs).
+Once these APIs are available, proceed with <<create_linux_bridge_nncp,creating a linux bridge network device>>.
+
+=== Create a Linux Bridge NodeNetworkConfigurationPolicy (NNCP) [[create_linux_bridge_nncp]]
+The first step is to define the Linux bridge on the cluster nodes using a NodeNetworkConfigurationPolicy (NNCP).
+NNCP objects are cluster-scoped, so they do not exist in a namespace.
+You can, however control which node(s)/host(s) to which the NNCP applies using key/value labels.
+
+NOTE: If you skip the NNCP step and try to boot a VM with a secondary bridge adapter, it will fail to start.
+
+==== Prerequisites: [[create_nncp_prereqs]]
+You must have first installed the Kubernetes NMState Operator and created a `nmstate` CR after installation.
+
+==== Procedure using the OpenShift console [[create_nncp_gui_procedure]]
+To create a NodeNetworkConfigurationPolicy, make sure you're still logged into the OpenShift admin console as a cluster admin before continuing on.
+
+From the console navigation menu (left pane), click *Networking* > *NodeNetworkConfigurationPolicy*.
+
+In the web frame, you'll see a button to *Create NodeNetworkConfigurationPolicy* if no NNCP currently exists. Otherwise, click *Create* > *From Form*.
+
+Complete the web form items as desired:
+
+* *Policy Name*: Set this to `lnbr0-policy` for the sake of this example
+* *Description* (optional): Add an optional description, for example `linux bridge lnbr0 with node port ens1`
+* *Interface Name*: Set this to `lnbr0` for this example
+* *Network state*: Leave *Up* selected 
+* *Type*: Linux bridge
+* *IP configuration* (optional): Check *IPv4* _only_ if you wish to set a static or DHCP address. Otherwise, leave this option unchecked (layer2-only).
+* *Port* (optional): Enter the name of a hardware interface on the node, which will be used to connect the bridge network externally (including to pods/VMs on other nodes/hosts).
+* *Enable STP* (optional): Check this if you want to enable spanning tree protocol for the bridge network.
+
+Once the form is complete, click *Create*.
+
+NOTE: As with `nmstate` objects, `nncp` objects are cluster-scoped, so the namespace is not required, although multiple `nncp` objects defining different networks can coexist on the cluster.
+
+Once the NNCP is created, proceed with <<create_net_attach_def,creating a network attachment definition>>.
+
+==== Procedure using the CLI: [[create_nncp_cli_procedure]]
+Create a NodeNetworkConfigurationPolicy manifest, choosing from either a static, dhcp, or layer2-only (link-level) configuration for the bridge interface.
+
+Launch a new/empty buffer in your favorite text editor, and name the file `lnbr0-policy.nncp.yaml`.
+
+Use one of the example yaml templates that aligns with your use-case below, paste it into the editor and modify it as desired.
+
+[NOTE]
+====
+.In each example:
+* `lnbr0` (shorthand for `linux bridge 0`) is used as the interface name of the Linux bridge.
+* `ens1` is the optional `port` adapter used to connect the bridge to the external network (including other nodes).
+* `stp` (spanning tree protocol) is disabled in these examples.
+* Whether configured as layer2, dhcp, or static, this affects the bridge interface addressing only, and does not affect pods/VMs.
+====
+
+.Static Configuration Example
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: lnbr0-policy
+spec:
+  desiredState:
+    interfaces:
+    - name: br0
+      description: static linux bridge with ens1 as a port
+      type: linux-bridge
+      state: up
+      ipv4:
+        address:
+        - ip: 192.168.1.89
+          prefix-length: 24
+        dhcp: false
+        enabled: true
+      bridge:
+        options:
+          stp:
+            enabled: false
+        port: ens1
+----
+
+.DHCP Configuration Example
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: lnbr0-policy
+spec:
+  desiredState:
+    interfaces:
+    - name: br0
+      description: dhcp linux bridge with ens1 as a port
+      type: linux-bridge
+      state: up
+      ipv4:
+        dhcp: true
+        enabled: true
+      bridge:
+        options:
+          stp:
+            enabled: false
+        port: ens1
+----
+
+.Layer2-only Configuration Example
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: lnbr0-policy
+spec:
+  desiredState:
+    interfaces:
+    - name: lnbr0
+      description: layer2-only linux bridge with ens1 as a port
+      type: linux-bridge
+      state: up
+      bridge:
+        options:
+          stp:
+            enabled: false
+        port: ens1
+----
+
+Apply the NNCP yaml file that was just created to the cluster:
+
+----
+oc create -f lnbr0-policy.nncp.yaml
+----
+
+After a few moments, each applicable node in the cluster will have a new bridge interface named `lnbr0` with the configured connection state.
+
+To confirm that the `lnbr0` interface exists on the node(s), you can either view the `NodeNetworkState` of the cluster, or start a debug session on a node.
+
+To view the `NodeNetworkState` for all nodes in the cluster, fetch the `nns` resource, and optionally `grep` for the bridge interface:
+
+----
+oc describe nns | grep lnbr0
+----
+
+If you prefer, open a debug session on a node to see things yourself:
+
+----
+oc debug node/worker0.example.com
+----
+
+Once you have a shell prompt on the node, use the `ip` tool to fetch the status of the bridge interface:
+
+----
+ip link show lnbr0
+----
+
+NOTE: As with `nmstate` objects, `nncp` objects are cluster-scoped, so the namespace is not required, although multiple `nncp` objects can coexist on the cluster.
+
+Once the existence of the Linux bridge interface is confirmed on the node(s), proceed with <<create_net_attach_def,creating a network attachment definition>>.
+
+
+=== Creating a Linux Bridge Network Attachment Definition (NAD) [[create_net_attach_def]]
+The next step is to create a Network Attachment Definition to provides Layer 2 networking to your pods/VMs.
+The NAD is what allows pods/VMs within a specific project/namespace to connect to a secondary network.
+
+==== Prerequisites [[create_nad_prereqs]]
+While not strictly required to create a network attachment definition, a NNCP defining the bridge interface must exist on the cluster before you attach a pod/VM to a bridge network. 
+Neglecting to do so will prevent any VM with a bridge-based NIC from booting.
+
+NOTE: A namespace containing VMs must either exist or be created before proceeding.
+
+==== Procedure using the CLI: [[create_nad_cli_procedure]]
+It is necessary to change to the project/namespace of the VMs before proceeding (replace `bridge-demo` with the namespace for where the VMs reside):
+
+----
+oc project bridge-demo
+----
+
+Launch an empty file/buffer in your favorite text editor and paste in the following yaml code, changing as needed:
+
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: lnbr0-nad
+  namespace: bridge-demo
+spec:
+  config: '{
+    "name": "lnbr0-nad",
+    "cniVersion": "0.3.1",
+    "type": "bridge",
+    "bridge": "lnbr0",
+    "ipam": {},
+    "vlan": 1,
+    "macspoofchk": false,
+    "disableContainerInterface": false,
+    "portIsolation": false
+  }'
+----
+
+Each field from the above example is explained below (optional fields are shown with their respective default values):
+
+* *metadata.name*: The K8s name of the NAD
+* *metadata.namespace*: This should match the namespace that the pods/VMs are running in (`bridge-demo` in this example).
+* *spec.config*: This field accepts a json string value with the following sub-fields:
+** *"name"*: The name of the configuration, which should ideally match `metadata.name`
+** *"cniVersion"*: CNI Version must currently be `"0.3.1"`.
+** *"type"* (required): Type must be set to `"bridge"` to use a Linux bridge interface.
+** *"bridge"* (required): The name of the bridge interface defined on nodes/hosts via the NNCP definition.
+** *"ipam"* (unsupported): This feature is not supported for virtualization, so it must be empty (layer2 only).
+** *"vlan"* (optional): The desired VLAN ID of the interface (defaults to `1`).
+** *"macspoofchk"* (optional): Enables mac spoof check, limiting traffic originating from the container to the mac address of the interface (defaults to `false`).
+** *"disableContainerInterface"* (optional): Disables the interface (veth peer) within the container, which disables IPAM. This does not affect IPAM usage within OpenShift Virtualization since it's not supported (defaults to `false`).
+** *"portIsolation"* (optional): Set isolation on the host interface. This prevents containers from communicating with each other, enforcing communication only with the host or through the gateway. (defaults to `false`)
+
+[IMPORTANT]
+====
+* Configuring IP address management (IPAM) in a network attachment definition for VMs is not supported, so the `"ipam": {}` definition must be empty.
+* The NAD must exist in the same namespace as the pods/VMs.
+* OpenShift Virtualization does not support https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/configuring_and_managing_networking/configuring-a-network-bond#upstream-switch-configuration-depending-on-the-bonding-modes[Linux bridge bonding modes] 0, 5, and 6.
+====
+
+Create the network attachment definition on OpenShift using the yaml file:
+
+----
+oc create -f network-attachment-definition.yaml
+----
+
+Verify that the NAD was successfully created:
+
+----
+oc get network-attachment-definition lnbr0-nad
+----
+
+With two of the three components in place, the last step is to <<configure_vm_nic,add a new virtual network adapter to the VM(s)>>.
+
+==== Procedure using the OpenShift console: [[create_nad_console_procedure]]
+
+From the web console, select *Networking* > *NetworkAttachmentDefinitions*.
+
+In the main web frame, use the pull down menu to select the *Project* that the VMs reside in.
+
+Click *Create Network Attachment Definition*.
+
+Type `lnbr0-nad` as the Policy name, and optionally provide a description.
+
+Scroll down to Policy Interface(s) and complete the form as follows:
+
+* *Interface Name*: `lnbr0`
+* *Type*: `Linux Bridge`
+* *IP configuration* (unsupported): check *IPv4* and optionally provide an IP address (such as 192.168.1.100) and desired prefix length, or select *DHCP*
+* *Port* (optional): enter a network interface name which exists on the node(s) (such as `ens1`) to use as the physical bridge adapter.
+* *VLAN tag number* (optional): if VLAN use is desired, enter the ID number in the VLAN Tag Number field. 
+* *MAC spoof check* (optional): enables MAC spoof filtering, which provides security by allowing only a single MAC address to exit the pod.
+
+Click *Create*.
+
+[NOTE]
+====
+* Only a subset of the supported configuration options for network attachment definitions are available when using the OpenShift Console.
+* For more advanced options & customization from the OpenShift console, you can use the YAML editor tab when creating or modifying a network attachment definition.
+* The node must support nftables and the nft binary must be deployed to enable MAC spoof check.
+====
+
+You should see the network attachment definition show up in the list once it's created. 
+
+=== Configuring the VM Network Interface [[configure_vm_nic]]
+Finally, you configure the virtual machine to use the newly created Linux bridge network attachment definition.
+
+==== Prerequisites [[vm_nic_prereqs]]
+The NMState operator, along with the `nmstate`, `nncp` and `network-attachment-definition` resources, should all exist in the cluster (the latter in the respective namespace of the VMs) before proceeding.
+
+The VMs must also already exist in OpenShift Virtualzation before proceeding. The VMs do not have to be running, but changes to running VMs will require restarting (or live migrating) before taking effect.
+
+==== Procedure using the OpenShift Console: [[vm_nic_console_procedure]]
+Navigate to *Virtualization* > *VirtualMachines*.
+
+Click on a VM to view its VirtualMachine details page.
+
+On the *Configuration* tab, then click the *Network* tab.
+
+Click *Add network interface*.
+
+Enter the interface Name and select the network attachment definition (`lnbr0-nad` in this example) from the Network list.
+
+Click *Save*.
+
+Restart or live migrate the VM to apply the changes.
+
+.Networking fields for VM interface configuration:
+* *Name*: Name for the network interface controller.
+* *Model*: Model of the network interface controller (supported values are e1000e and virtio).
+* *Network*: List of available network attachment definitions.
+* *Type*: Binding method (select bridge for a Linux bridge network).
+* *MAC Address*: MAC address for the network interface controller. If not specified, one is assigned automatically.
+
+==== Procedure using the CLI: [[vm_nic_cli_procedure]]
+
+Start by fetching the existing VM configuration in yaml format. In the following example, we use a VM named `bridge-example-0` in the namespace `bridge-example`, and an output file named `bridge-example.vm.yaml`:
+
+----
+oc get vm bridge-example-0 -n bridge-example -o yaml > bridge-example.vm.yaml
+----
+
+Edit the file you've just created. Add the VM bridge interface and the NAD binding to the VM yaml configuration via the `spec.template.spec.domain.devices.interfaces` and `spec.template.spec.networks` sections.
+
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: bridge-example-0
+  namespace: bridge-example
+spec:
+  ...
+  template:
+    ...
+    spec:
+      ...
+      domain:
+        ...
+        devices:
+          ...
+          interfaces:
+          - macAddress: 'ff:00:ba:ff:00:ba'
+            masquerade: {}
+            name: default
+          - bridge: {}
+            macAddress: 'ba:00:ff:ba:00:ff'
+            model: virtio
+            name: nic-linux-bridge-0
+      ...
+      networks:
+      - name: default
+        pod: {}
+      - multus:
+          networkName: nad-lnbr0
+        name: nic-linux-bridge-0
+  ...
+----
+
+Reviewing the two primary fields in the above example:
+
+* *spec.template.spec.domain.devices.interfaces*:
+** *`bridge`*: an empty definition `{}` here is sufficient.
+** *`macAddress`*: You specify a mac address or leave this field empty and it will auto-generate.
+** *`model`*: `virtio` (virtualized hardware) is chosen over `e1000` (emulated adapter) for performance gains in Linux.
+** *`name`*: An arbitrary identifier which gets referred to later in the `network` section.
+* *spec.template.spec.networks*:
+** *`name`*: This is the name of the bridge interface as defined in the `interfaces` field.
+** *`multus.networkName`*: The name of the NAD providing pods/VMs access to the bridge network.
+
+Once you've edited and saved the yaml file, apply the VM configuration to the cluster:
+
+----
+oc apply -f bridge-example.vm.yaml
+----
+
+NOTE: If you edited a running virtual machine, you must restart or live migrate it for the changes to take effect.
+
+The Linux bridge should now be visible from the VM (after a restart, as mentioned). You can use the `nmcli` tool or Windows Settings/Control Panel inside the container to configure the IP address of the bridge interface.

--- a/modules/networking/pages/localnet-secondary.adoc
+++ b/modules/networking/pages/localnet-secondary.adoc
@@ -1,0 +1,209 @@
+= Configuring Localnet Secondary Networks with ClusterUserDefinedNetwork in OpenShift Virtualization
+:navtitle: Localnet Secondary Networks with CUDN
+
+This tutorial demonstrates how to configure localnet secondary networks using ClusterUserDefinedNetwork (CUDN) in OpenShift Virtualization. Localnet topology provides direct access to physical network infrastructure, enabling VMs to communicate with external networks while maintaining pod network connectivity. This approach is ideal for integrating with existing infrastructure or legacy systems requiring layer 2 connectivity.
+
+== Prerequisites
+
+* **NMState Operator**: Must be installed and running in the cluster
+* **NMState CR**: The nmstate instance must be created after the operator is running
+* **Worker nodes**: The bridge mapping will be applied to worker nodes
+
+Versions tested:
+----
+OCP 4.19
+----
+
+== Step 1: Create VM Namespace
+
+Create a namespace for VMs that will use the localnet secondary network.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vm-guests-localnet
+EOF
+----
+
+== Step 2: Configure Bridge Mapping
+
+Configure the bridge mapping that connects the logical physnet name to the `br-ex` bridge interface. This tells OVN-Kubernetes which physical interface handles localnet traffic.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: localnet-bridge-mapping
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ''  
+  desiredState:
+    ovn:
+      bridge-mappings:
+      - localnet: localnet1
+        bridge: br-ex
+        state: present
+EOF
+----
+
+**Note**: This maps the logical `localnet1` name to the `br-ex` bridge on worker nodes, enabling VM access to external networks.
+
+== Step 3: Create ClusterUserDefinedNetwork
+
+Create a ClusterUserDefinedNetwork with localnet topology for secondary network connectivity to external networks.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: k8s.ovn.org/v1
+kind: ClusterUserDefinedNetwork
+metadata:
+  name: cudn-localnet
+spec:
+  namespaceSelector: 
+    matchExpressions: 
+    - key: kubernetes.io/metadata.name
+      operator: In 
+      values: ["vm-guests-localnet"]
+  network:
+    topology: Localnet 
+    localnet:
+        role: Secondary 
+        physicalNetworkName: localnet1 
+        ipam:
+          mode: Disabled
+EOF
+----
+
+== Step 4: Deploy VM with Dual Network Connectivity
+
+Create a VM that connects to both the pod network and the localnet secondary network for dual connectivity.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora-localnet-vm
+  namespace: vm-guests-localnet
+  labels:
+    app: fedora-localnet-vm
+spec:
+  runStrategy: Always
+  dataVolumeTemplates:
+  - metadata:
+      name: fedora-localnet-volume
+    spec:
+      pvc:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 33Gi
+      sourceRef:
+        kind: DataSource
+        name: fedora
+        namespace: openshift-virtualization-os-images
+  template:
+    metadata:
+      labels:
+        app: fedora-localnet-vm
+    spec:
+      domain:
+        devices:
+          disks:
+          - name: datavolumedisk
+            disk:
+              bus: virtio
+          - name: cloudinitdisk
+            disk:
+              bus: virtio
+          interfaces:
+          - name: default
+            bridge: {}
+          - name: secondary_localnet
+            bridge: {}
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 1
+      networks:
+      - name: default
+        pod: {}
+      - name: secondary_localnet
+        multus:
+          networkName: cudn-localnet
+      volumes:
+      - name: datavolumedisk
+        dataVolume:
+          name: fedora-localnet-volume
+      - name: cloudinitdisk
+        cloudInitNoCloud:
+          userData: |
+            #cloud-config
+            user: fedora
+            password: fedora
+            chpasswd: { expire: False }
+            packages:
+            - python3
+            runcmd:
+            - echo "<h1>Welcome to OpenShift Virtualization Localnet!</h1>" > /root/index.html
+            - cd /root && nohup python3 -m http.server 8080 > /dev/null 2>&1 &
+EOF
+----
+
+== Step 5: Verify Network Connectivity
+
+Access the VM console to verify dual network connectivity.
+
+[source,bash,role=execute]
+----
+# Check the VM status
+oc get vm -n vm-guests-localnet
+
+# Check the running VM instance
+oc get vmi -n vm-guests-localnet
+
+# Access the VM console (credentials: fedora/fedora via cloud-init)
+virtctl console -n vm-guests-localnet fedora-localnet-vm
+----
+
+Inside the VM console, verify the network configuration:
+
+[source,bash,role=execute]
+----
+# Check network interfaces - primary (pod network) and secondary (localnet)
+ip addr show
+
+# Check routes - two default gateways (lower metric prioritized)
+# Primary network: metric 100, Secondary: metric 101
+ip route show
+
+# Expected output example:
+
+default via 10.128.0.1 dev enp1s0 proto dhcp src 10.128.0.172 metric 100 
+default via 192.168.2.1 dev enp2s0 proto dhcp src 192.168.2.128 metric 101 
+
+# Test external connectivity
+ping 8.8.8.8
+
+# Verify the web service is running
+curl localhost:8080
+
+# Test localnet interface connectivity (replace <localnet-ip> with actual IP)
+curl <localnet-ip>:8080
+----
+
+== References
+
+=== OpenShift Documentation
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/multiple_networks/understanding-multiple-networks[OpenShift - Understanding Multiple Networks,window=_blank]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/virtualization/networking#virt-creating-secondary-localnet-udn_virt-connecting-vm-to-secondary-udn[Localnet Topology Configuration for OCP Virtualization,window=_blank]
+

--- a/modules/networking/pages/localnet-vlan.adoc
+++ b/modules/networking/pages/localnet-vlan.adoc
@@ -1,0 +1,266 @@
+= Configuring Localnet Secondary Networks with VLAN using NetworkAttachmentDefinition in OpenShift Virtualization
+:navtitle: Localnet Secondary Networks with VLAN using NAD
+
+This tutorial demonstrates how to configure localnet secondary networks with VLAN tagging using NetworkAttachmentDefinition (NAD) in OpenShift Virtualization. This approach provides direct access to physical network infrastructure with VLAN segmentation, enabling VMs to communicate with specific VLAN-tagged networks while maintaining pod network connectivity. This is ideal for integrating with existing VLAN-based network infrastructure or when network segmentation is required.
+
+== Prerequisites
+
+* **NMState Operator**: Must be installed and running in the cluster
+* **NMState CR**: The nmstate instance must be created after the operator is running
+* **Worker nodes**: The bridge mapping will be applied to worker nodes
+* **VLAN Infrastructure**: Physical network infrastructure must support VLAN tagging
+* **Switch Configuration**: Physical switch ports connected to OpenShift worker nodes must be configured in **trunk mode** to handle multiple VLAN-tagged traffic streams
+
+Versions tested:
+----
+OCP 4.19
+----
+
+== Network Configuration Requirements
+
+=== Physical Switch Configuration: TRUNK MODE
+
+The physical switch ports connected to OpenShift worker nodes **must be configured in trunk mode** for localnet VLAN configuration to work properly:
+
+* **Trunk mode**: Allows switch ports to carry traffic for multiple VLANs
+* **VLAN tagging**: Each VLAN is identified by its unique VLAN ID (e.g., 100, 200, 300)
+* **Multiple networks**: Essential for supporting multiple VLAN-based secondary networks
+
+== Step 1: Create VM Namespace
+
+Create a namespace for VMs that will use the localnet secondary network with VLAN configuration.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vm-guests-vlan
+EOF
+----
+
+== Step 2: Configure Bridge Mapping
+
+Configure the bridge mapping that connects the logical network interface name `localnet-vlan` to the `br-ex` bridge interface on worker nodes. This mapping tells OVN-Kubernetes which physical bridge interface handles localnet traffic with VLAN support, enabling VM access to VLAN-tagged external networks through the underlying physical network infrastructure.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: localnet-vlan-bridge-mapping
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ''  
+  desiredState:
+    ovn:
+      bridge-mappings:
+      - localnet: localnet-vlan
+        bridge: br-ex
+        state: present
+EOF
+----
+
+== Step 3: Create NetworkAttachmentDefinition with VLAN
+
+Create a NetworkAttachmentDefinition that configures localnet topology with VLAN tagging for secondary network connectivity.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: localnet-vlan-100
+  namespace: vm-guests-vlan
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "name": "localnet-vlan-100",
+    "type": "ovn-k8s-cni-overlay",
+    "topology": "localnet",
+    "netAttachDefName": "vm-guests-vlan/localnet-vlan-100",
+    "vlanID": 100,
+    "subnets": "192.168.100.0/24",
+    "excludeSubnets": "192.168.100.1/32"
+  }'
+EOF
+----
+
+**Configuration Details**:
+
+* `vlanID: 100`: Specifies VLAN tag 100 for network segmentation
+* `subnets`: Defines the expected IP subnet range for documentation and validation purposes
+* `excludeSubnets`: Excludes gateway IP from being assigned (typically reserved for router/gateway)
+* `topology: "localnet"`: Uses localnet topology for direct physical network access
+* **No IPAM configuration**: IP addresses require external DHCP server on the VLAN network or VMs need to be configured statically
+
+== Step 4: Deploy VM with VLAN Network Connectivity
+
+Create a VM that connects to both the pod network and the VLAN-tagged localnet secondary network.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora-vlan-vm
+  namespace: vm-guests-vlan
+  labels:
+    app: fedora-vlan-vm
+spec:
+  runStrategy: Always
+  dataVolumeTemplates:
+  - metadata:
+      name: fedora-vlan-volume
+    spec:
+      pvc:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 33Gi
+      sourceRef:
+        kind: DataSource
+        name: fedora
+        namespace: openshift-virtualization-os-images
+  template:
+    metadata:
+      labels:
+        app: fedora-vlan-vm
+    spec:
+      domain:
+        devices:
+          disks:
+          - name: datavolumedisk
+            disk:
+              bus: virtio
+          - name: cloudinitdisk
+            disk:
+              bus: virtio
+          interfaces:
+          - name: default
+            bridge: {}
+          - name: vlan_network
+            bridge: {}
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 1
+      networks:
+      - name: default
+        pod: {}
+      - name: vlan_network
+        multus:
+          networkName: localnet-vlan-100
+      volumes:
+      - name: datavolumedisk
+        dataVolume:
+          name: fedora-vlan-volume
+      - name: cloudinitdisk
+        cloudInitNoCloud:
+          userData: |
+            #cloud-config
+            user: fedora
+            password: fedora
+            chpasswd: { expire: False }
+            packages:
+            - python3
+            - tcpdump
+            - net-tools
+            runcmd:
+            - echo "<h1>Welcome to OpenShift Virtualization VLAN Network!</h1>" > /root/index.html
+            - echo "<p>VLAN ID: 100</p>" >> /root/index.html
+            - echo "<p>Network: 192.168.100.0/24</p>" >> /root/index.html
+            - cd /root && nohup python3 -m http.server 8080 > /dev/null 2>&1 &
+EOF
+----
+
+== Step 5: Verify VLAN Network Connectivity
+
+Access the VM console to verify dual network connectivity with VLAN configuration.
+
+[source,bash,role=execute]
+----
+# Check the VM status
+oc get vm -n vm-guests-vlan
+
+# Check the running VM instance
+oc get vmi -n vm-guests-vlan
+
+# Access the VM console (credentials: fedora/fedora via cloud-init)
+virtctl console -n vm-guests-vlan fedora-vlan-vm
+----
+
+Inside the VM console, verify the VLAN network configuration:
+
+[source,bash,role=execute]
+----
+# Check network interfaces - primary (pod network) and secondary (VLAN network)
+ip addr show
+
+# Check routes - two default gateways (lower metric prioritized)
+# Primary network: metric 100, Secondary VLAN: metric 101
+ip route show
+
+# Expected output example:
+default via 10.128.0.1 dev enp1s0 proto dhcp src 10.128.0.172 metric 100 
+default via 192.168.100.1 dev enp2s0 proto dhcp src 192.168.100.50 metric 101 
+
+# Test external connectivity
+ping 8.8.8.8
+
+# Verify the web service is running
+curl localhost:8080
+
+# Test VLAN interface connectivity (replace <vlan-ip> with actual IP)
+curl <vlan-ip>:8080
+
+# Verify VLAN tagging (if tcpdump is available)
+# This will show VLAN-tagged traffic on the secondary interface
+sudo tcpdump -i enp2s0 -nn vlan 100
+----
+
+== Troubleshooting
+
+=== Common Issues
+
+. **VLAN Traffic Not Reaching VM**:
+   * Verify physical switch configuration supports VLAN tagging
+   * Check bridge mapping configuration on worker nodes
+   * Ensure VLAN ID matches network infrastructure
+
+. **IP Address Assignment Issues**:
+   * Verify DHCP server is available on the VLAN network
+
+. **Network Connectivity Problems**:
+   * Check that the physical network supports the configured VLAN
+   * Test connectivity from physical network to VLAN subnet
+
+=== Verification Commands
+
+[source,bash,role=execute]
+----
+# Check NetworkAttachmentDefinition status
+oc get network-attachment-definitions -n vm-guests-vlan
+
+# Verify bridge mapping on worker nodes
+oc get nncp localnet-vlan-bridge-mapping -o yaml
+
+# Check VM network status
+oc get vmi -n vm-guests-vlan -o yaml | grep -A 10 networks
+
+# View OVN-Kubernetes logs for troubleshooting
+oc logs -n openshift-ovn-kubernetes -l app=ovnkube-node
+----
+
+== References
+
+=== OpenShift Documentation
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/multiple_networks/understanding-multiple-networks[OpenShift - Understanding Multiple Networks,window=_blank]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/virtualization/networking#virt-creating-secondary-localnet-udn_virt-connecting-vm-to-secondary-udn[Localnet Topology Configuration for OCP Virtualization,window=_blank]
+

--- a/modules/networking/pages/ovs-bridge-verification.adoc
+++ b/modules/networking/pages/ovs-bridge-verification.adoc
@@ -1,0 +1,810 @@
+= Troubleshooting OVS Bridge Creation for Localnet Networks
+:navtitle: OVS Bridge Verification
+
+This guide helps you verify that OVS (Open vSwitch) bridges are correctly created and configured for localnet secondary networks in OpenShift Virtualization.
+
+== Understanding OVS Bridges vs Linux Bridges
+
+**Important**: OVS bridges behave differently from Linux bridges:
+
+* **OVS bridges** are visible using `ovs-vsctl` commands
+* **OVS bridges** may NOT appear as regular network interfaces in `ip addr show` or `ip link show`
+* This is **normal and expected behavior** - OVS bridges exist in the OVS database, not as standard Linux network devices
+
+== Verification Process
+
+=== Step 1: Check NodeNetworkConfigurationPolicy Status
+
+First, verify that your NNCP was applied and configured successfully:
+
+[source,bash,role=execute]
+----
+# List all NNCPs
+oc get nncp
+
+# Check specific NNCP status
+oc get nncp br-vlan-creation
+----
+
+**Expected Output:**
+
+----
+NAME               STATUS      REASON
+br-vlan-creation   Available   SuccessfullyConfigured
+----
+
+=== Step 2: Get Detailed NNCP Information
+
+Review the full NNCP configuration and status:
+
+[source,bash,role=execute]
+----
+oc get nncp br-vlan-creation -o yaml
+----
+
+**Look for these key indicators in the output:**
+
+[source,yaml]
+----
+status:
+  conditions:
+  - lastHeartbeatTime: "2025-10-06T20:38:57Z"
+    lastTransitionTime: "2025-10-06T20:38:57Z"
+    message: 1/1 nodes successfully configured
+    reason: SuccessfullyConfigured
+    status: "True"
+    type: Available
+  - reason: SuccessfullyConfigured
+    status: "False"
+    type: Degraded
+----
+
+* `Available: True` with `SuccessfullyConfigured` = Configuration applied
+* `Degraded: False` = No issues detected
+* `message: X/X nodes successfully configured` = All nodes configured
+
+=== Step 3: Verify OVS Bridge Exists
+
+**This is the correct way to check for OVS bridges:**
+
+[source,bash,role=execute]
+----
+# Get your node name
+oc get nodes
+
+# List all OVS bridges
+oc debug node/<node-name> -- chroot /host ovs-vsctl list-br
+----
+
+**Example Output:**
+
+----
+Starting pod/ocplab01-debug-k7bfc ...
+To use host binaries, run `chroot /host`
+br-ex
+br-int
+br-vlan
+
+Removing debug pod ...
+----
+
+If you see `br-vlan` in this list, your bridge was created successfully!
+
+=== Step 4: Verify Bridge Configuration Details
+
+Check the complete OVS configuration to see bridge ports and interfaces:
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host ovs-vsctl show
+----
+
+**Example Output (relevant section):**
+
+----
+Bridge br-vlan
+    Port enp11s0f0np0
+        Interface enp11s0f0np0
+            type: system
+----
+
+**What to verify:**
+
+* Bridge name (`br-vlan`) appears in the output
+* Your physical interface (e.g., `enp11s0f0np0`) is listed as a Port
+* Interface type is `system` for physical interfaces
+
+=== Step 5: Verify Physical Interface Status
+
+Ensure the physical interface is attached to the bridge and in UP state:
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host ip link show <interface-name>
+----
+
+**Example Output:**
+
+----
+4: enp11s0f0np0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq master ovs-system state UP mode DEFAULT group default qlen 1000
+    link/ether e8:eb:d3:13:06:16 brd ff:ff:ff:ff:ff:ff
+----
+
+**What to verify:**
+
+* `UP,LOWER_UP` - interface is operational
+* `master ovs-system` - interface is managed by OVS
+* `state UP` - interface state is up
+
+=== Step 6: Why "ip addr show br-vlan" Fails
+
+**This is NORMAL behavior:**
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host ip addr show br-vlan
+----
+
+**Expected Result:**
+
+----
+Device "br-vlan" does not exist.
+----
+
+**Why this happens:**
+
+* OVS bridges exist in the OVS database, not as regular Linux network devices
+* They won't appear in standard `ip` command outputs unless they have an internal interface
+* This does NOT mean your bridge creation failed
+* Always use `ovs-vsctl` commands to verify OVS bridges
+
+== Common Issues and Solutions
+
+=== Issue 1: Bridge Not Appearing in ovs-vsctl list-br
+
+**Symptoms:**
+
+* NNCP shows `Available: True` but bridge not in `ovs-vsctl list-br`
+
+**Troubleshooting:**
+
+[source,bash,role=execute]
+----
+# Check NNCP conditions
+oc get nncp br-vlan-creation -o jsonpath='{.status.conditions[?(@.type=="Available")]}' | jq
+
+# Check NMState operator logs
+oc logs -n openshift-nmstate -l app=kubernetes-nmstate-operator
+
+# Check if there are any node network states with issues
+oc get nns -A
+----
+
+**Common causes:**
+
+* Physical interface name mismatch (verify with `ip link show`)
+* OVS not running properly on the node
+* NMState operator issues
+
+=== Issue 2: Physical Interface Not Attached to Bridge
+
+**Symptoms:**
+
+* Bridge exists but `ovs-vsctl show` doesn't show your interface as a port
+
+**Troubleshooting:**
+
+[source,bash,role=execute]
+----
+# List all ports on the bridge
+oc debug node/<node-name> -- chroot /host ovs-vsctl list-ports br-vlan
+
+# Check interface status
+oc debug node/<node-name> -- chroot /host ip link show <interface-name>
+
+# Verify NNCP configuration has correct interface name
+oc get nncp br-vlan-creation -o yaml | grep -A 5 "name: <interface-name>"
+----
+
+**Solutions:**
+
+. Verify physical interface name is correct in NNCP
+. Check that interface is not already in use by another bridge
+. Ensure interface exists and is available on the node
+
+=== Issue 3: Node Selector Mismatch
+
+**Symptoms:**
+
+* NNCP shows successful but bridge doesn't exist
+
+**Troubleshooting:**
+
+[source,bash,role=execute]
+----
+# Check node labels
+oc get nodes --show-labels
+
+# Check NNCP node selector
+oc get nncp br-vlan-creation -o jsonpath='{.spec.nodeSelector}'
+----
+
+**Common issue:**
+
+* Single Node OpenShift (SNO) nodes have `control-plane,master,worker` roles
+* NNCP with `node-role.kubernetes.io/worker: ""` selector will still match
+* Verify the NNCP status shows "X/X nodes successfully configured"
+
+=== Issue 4: Bridge Created But Not Working
+
+**Symptoms:**
+
+* Bridge exists, interface attached, but traffic not flowing
+
+**Troubleshooting:**
+
+[source,bash,role=execute]
+----
+# Check interface carrier status
+oc debug node/<node-name> -- chroot /host cat /sys/class/net/<interface-name>/carrier
+
+# Check for interface errors
+oc debug node/<node-name> -- chroot /host ethtool -S <interface-name>
+
+# Verify physical link is up
+oc debug node/<node-name> -- chroot /host ethtool <interface-name> | grep "Link detected"
+----
+
+**Common causes:**
+
+* Physical cable not connected
+* Switch port disabled or misconfigured
+* Interface speed/duplex mismatch
+
+== Verifying Bridge Mappings for Localnet
+
+After creating the OVS bridge, you need to verify that the bridge mapping to OVN-Kubernetes is working correctly.
+
+=== What Are Bridge Mappings?
+
+Bridge mappings connect a **logical network name** (used in NetworkAttachmentDefinitions) to a **physical OVS bridge**. For example:
+
+* Logical name: `localnet-vlan`
+* Physical bridge: `br-vlan`
+* Mapping: `localnet-vlan:br-vlan`
+
+=== Step 1: Verify Bridge Mapping NNCP Status
+
+Check that the bridge mapping NNCP was applied successfully:
+
+[source,bash,role=execute]
+----
+# List all NNCPs
+oc get nncp | grep mapping
+
+# Check specific bridge mapping NNCP
+oc get nncp localnet-vlan-bridge-mapping
+----
+
+**Expected Output:**
+
+----
+localnet-vlan-bridge-mapping   Available   SuccessfullyConfigured
+----
+
+=== Step 2: Get Detailed Bridge Mapping Configuration
+
+[source,bash,role=execute]
+----
+oc get nncp localnet-vlan-bridge-mapping -o yaml
+----
+
+**Look for these key sections in the output:**
+
+[source,yaml]
+----
+spec:
+  desiredState:
+    ovn:
+      bridge-mappings:
+      - bridge: br-vlan
+        localnet: localnet-vlan
+        state: present
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+status:
+  conditions:
+  - message: 1/1 nodes successfully configured
+    reason: SuccessfullyConfigured
+    status: "True"
+    type: Available
+----
+
+=== Step 3: Verify OVN Bridge Mappings on the Node
+
+This is the **critical verification** - check that OVN-Kubernetes has the bridge mapping configured:
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host ovs-vsctl get Open_vSwitch . external_ids:ovn-bridge-mappings
+----
+
+**Expected Output:**
+
+----
+"localnet-vlan:br-vlan,physnet:br-ex"
+----
+
+**What this means:**
+
+* `localnet-vlan:br-vlan` = Your custom mapping
+* `physnet:br-ex` = Default OpenShift mapping
+* Multiple mappings are comma-separated
+
+=== Step 4: Verify Complete OVS External IDs
+
+Get all OVS external IDs to see the full configuration:
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host ovs-vsctl list Open_vSwitch | grep -A 2 external_ids
+----
+
+**Example Output:**
+
+----
+external_ids        : {hostname=ocplab01, ovn-bridge-mappings="localnet-vlan:br-vlan,physnet:br-ex", ovn-bridge-remote-probe-interval="0", ovn-enable-lflow-cache="true", ovn-encap-ip="192.168.2.241", ovn-encap-type=geneve, ovn-is-interconn="true", ovn-memlimit-lflow-cache-kb="1048576", ovn-monitor-all="true", ovn-ofctrl-wait-before-clear="0", ovn-remote="unix:/var/run/ovn/ovnsb_db.sock", ovn-remote-probe-interval="180000", ovn-set-local-ip="true", rundir="/var/run/openvswitch", system-id="1b41fc3f-f597-4cd9-b508-e8247c209d97"}
+----
+
+**Verify:**
+
+* `ovn-bridge-mappings` includes your mapping
+* `hostname` matches your node
+* `ovn-encap-type=geneve` is present
+
+=== Step 5: Verify Physical Interface is Attached
+
+Confirm the physical interface is attached to the bridge:
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host ovs-vsctl list-ports br-vlan
+----
+
+**Expected Output:**
+
+----
+enp11s0f0np0
+----
+
+This confirms your physical interface is a port on the bridge and ready to carry traffic.
+
+== Bridge Mapping Traffic Flow
+
+Understanding how traffic flows through bridge mappings:
+
+----
+┌─────────────────────────────────────────────────────────────────┐
+│ Virtual Machine                                                  │
+│   └─> eth1 (secondary network interface)                        │
+└────────────────────────┬────────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ NetworkAttachmentDefinition                                      │
+│   - name: localnet-vlan-100                                      │
+│   - topology: localnet                                           │
+│   - vlanID: 100                                                  │
+└────────────────────────┬────────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ OVN-Kubernetes (looks up bridge mapping)                         │
+│   localnet-vlan → br-vlan                                        │
+└────────────────────────┬────────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ OVS Bridge: br-vlan                                              │
+│   - Adds VLAN tag 100                                            │
+│   - Routes to physical interface                                 │
+└────────────────────────┬────────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ Physical Interface: enp11s0f0np0                                 │
+│   - Sends VLAN-tagged traffic to physical network               │
+└─────────────────────────────────────────────────────────────────┘
+----
+
+== Troubleshooting Bridge Mapping Issues
+
+=== Issue 1: Bridge Mapping Not in OVN External IDs
+
+**Symptoms:**
+
+* NNCP shows successful but `ovs-vsctl get Open_vSwitch . external_ids:ovn-bridge-mappings` doesn't include your mapping
+
+**Troubleshooting:**
+
+[source,bash,role=execute]
+----
+# Check NNCP was applied
+oc get nncp localnet-vlan-bridge-mapping -o yaml
+
+# Restart NMState operator
+oc delete pod -n openshift-nmstate -l app=kubernetes-nmstate-operator
+
+# Check NMState handler logs
+oc logs -n openshift-nmstate -l component=kubernetes-nmstate-handler
+----
+
+**Common causes:**
+
+* NNCP applied before bridge was created
+* NMState handler not running properly
+* OVS service issues
+
+**Solution:**
+
+Delete and recreate the bridge mapping NNCP after confirming the bridge exists.
+
+=== Issue 2: Wrong Bridge Name in Mapping
+
+**Symptoms:**
+
+* Bridge mapping exists but uses wrong bridge name
+
+**Verification:**
+
+[source,bash,role=execute]
+----
+# Check what bridges exist
+oc debug node/<node-name> -- chroot /host ovs-vsctl list-br
+
+# Check what mapping references
+oc get nncp localnet-vlan-bridge-mapping -o jsonpath='{.spec.desiredState.ovn.bridge-mappings[0].bridge}'
+----
+
+**Solution:**
+
+Ensure the bridge name in the mapping NNCP matches the actual OVS bridge name exactly.
+
+=== Issue 3: Logical Name Mismatch
+
+**Symptoms:**
+
+* VMs can't connect to network even though bridge mapping exists
+
+**Verification:**
+
+[source,bash,role=execute]
+----
+# Check logical name in bridge mapping
+oc get nncp localnet-vlan-bridge-mapping -o jsonpath='{.spec.desiredState.ovn.bridge-mappings[0].localnet}'
+
+# Check NetworkAttachmentDefinition or CUDN references the same name
+oc get network-attachment-definitions <nad-name> -n <namespace> -o yaml
+----
+
+**Solution:**
+
+The logical network name in the bridge mapping must match the name used in your NetworkAttachmentDefinition or ClusterUserDefinedNetwork configuration.
+
+=== Issue 4: Multiple Mappings Conflict
+
+**Symptoms:**
+
+* Multiple bridge mappings configured but traffic goes to wrong bridge
+
+**Verification:**
+
+[source,bash,role=execute]
+----
+# List all bridge mappings
+oc debug node/<node-name> -- chroot /host ovs-vsctl get Open_vSwitch . external_ids:ovn-bridge-mappings
+----
+
+**Expected format:**
+
+----
+"mapping1:bridge1,mapping2:bridge2,mapping3:bridge3"
+----
+
+**Solution:**
+
+Ensure each logical network name is unique and maps to the correct bridge. OVN will use the first matching mapping.
+
+== Complete Verification Checklist
+
+Use this checklist to verify your OVS bridge and bridge mappings are correctly configured:
+
+=== Bridge Creation
+
+* [ ] NNCP status shows `Available: True` with `SuccessfullyConfigured`
+* [ ] NNCP message shows all nodes successfully configured
+* [ ] `ovs-vsctl list-br` includes your bridge name
+* [ ] `ovs-vsctl show` displays bridge with physical interface as port
+* [ ] Physical interface shows `UP,LOWER_UP` status
+* [ ] Physical interface shows `master ovs-system`
+* [ ] Physical link has carrier (cable connected)
+* [ ] No errors in NMState operator logs
+
+=== Bridge Mapping
+
+* [ ] Bridge mapping NNCP shows `Available: True`
+* [ ] `ovs-vsctl get Open_vSwitch . external_ids:ovn-bridge-mappings` includes your mapping
+* [ ] Mapping format is correct: `logical-name:bridge-name`
+* [ ] Logical network name matches what you'll use in NAD/CUDN
+* [ ] Bridge name in mapping matches actual OVS bridge
+* [ ] Physical interface is attached to the bridge (`ovs-vsctl list-ports`)
+* [ ] No conflicts with other bridge mappings
+
+== Additional Verification Commands
+
+=== Check OVS Service Status
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host systemctl status openvswitch
+----
+
+=== View OVS Logs
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host journalctl -u openvswitch -n 50
+----
+
+=== List All OVS Interfaces
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host ovs-vsctl list interface
+----
+
+=== Check OVS Database
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host ovs-vsctl list bridge
+----
+
+=== Monitor OVS Bridge Traffic (Optional)
+
+[source,bash,role=execute]
+----
+# View ports and their statistics
+oc debug node/<node-name> -- chroot /host ovs-ofctl dump-ports br-vlan
+----
+
+== ClusterUserDefinedNetwork (CUDN) Verification
+
+When using ClusterUserDefinedNetwork instead of NetworkAttachmentDefinition, additional verification steps are needed.
+
+=== Step 1: Verify CUDN Resource
+
+Check that the ClusterUserDefinedNetwork was created successfully:
+
+[source,bash,role=execute]
+----
+# List all CUDNs
+oc get clusteruserdefinednetwork
+
+# Get detailed CUDN information
+oc get clusteruserdefinednetwork <cudn-name> -o yaml
+----
+
+**Expected Output:**
+
+----
+NAME                     AGE
+cudn-localnet-vlan-100   5m
+----
+
+=== Step 2: Verify CUDN Configuration
+
+Check the CUDN spec to ensure proper configuration:
+
+[source,bash,role=execute]
+----
+oc get clusteruserdefinednetwork cudn-localnet-vlan-100 -o yaml
+----
+
+**Key fields to verify:**
+
+[source,yaml]
+----
+spec:
+  namespaceSelector: 
+    matchExpressions: 
+    - key: kubernetes.io/metadata.name
+      operator: In 
+      values: ["vm-guests-vlan-prod", "vm-guests-vlan-dev"]
+  network:
+    topology: Localnet 
+    localnet:
+      role: Secondary 
+      physicalNetworkName: localnet-vlan  # Must match bridge mapping logical name
+      vlanID: 100
+      ipam:
+        mode: Disabled  # Or Static depending on your needs
+----
+
+=== Step 3: Verify Auto-Created NetworkAttachmentDefinitions
+
+CUDNs automatically create NetworkAttachmentDefinitions in the selected namespaces:
+
+[source,bash,role=execute]
+----
+# List NADs in all namespaces
+oc get network-attachment-definitions -A | grep <cudn-name>
+
+# Check specific namespace
+oc get network-attachment-definitions -n <namespace>
+----
+
+**Expected Output:**
+
+----
+NAMESPACE             NAME                     AGE
+vm-guests-vlan-dev    cudn-localnet-vlan-100   5m
+vm-guests-vlan-prod   cudn-localnet-vlan-100   5m
+----
+
+=== Step 4: Verify physicalNetworkName Matches Bridge Mapping
+
+The `physicalNetworkName` in CUDN must match the logical network name in your bridge mapping:
+
+[source,bash,role=execute]
+----
+# Get CUDN physicalNetworkName
+oc get clusteruserdefinednetwork <cudn-name> -o jsonpath='{.spec.network.localnet.physicalNetworkName}'
+
+# Get bridge mapping logical name
+oc get nncp <bridge-mapping-nncp> -o jsonpath='{.spec.desiredState.ovn.bridge-mappings[0].localnet}'
+
+# Verify they match in OVN
+oc debug node/<node-name> -- chroot /host ovs-vsctl get Open_vSwitch . external_ids:ovn-bridge-mappings
+----
+
+**All three should show the same name** (e.g., `localnet-vlan`).
+
+=== Step 5: Verify Cross-Namespace Network Availability
+
+Test that VMs in different namespaces can both use the CUDN:
+
+[source,bash,role=execute]
+----
+# Check VMs in first namespace
+oc get vmi -n vm-guests-vlan-prod -o jsonpath='{.items[*].status.interfaces[?(@.name=="cudn_vlan_network")].ipAddress}'
+
+# Check VMs in second namespace
+oc get vmi -n vm-guests-vlan-dev -o jsonpath='{.items[*].status.interfaces[?(@.name=="cudn_vlan_network")].ipAddress}'
+----
+
+Both should return IP addresses if VMs are connected to the CUDN network.
+
+=== CUDN-Specific Common Issues
+
+. **NADs Not Created in Selected Namespaces**:
+   * **Symptom**: CUDN exists but `oc get network-attachment-definitions -n <namespace>` shows nothing
+   * **Cause**: Namespace selector doesn't match namespace labels
+   * **Solution**: Verify namespace labels match the CUDN selector
++
+[source,bash,role=execute]
+----
+# Check namespace labels
+oc get namespace <namespace-name> -o jsonpath='{.metadata.labels}'
+
+# Check CUDN selector
+oc get clusteruserdefinednetwork <cudn-name> -o jsonpath='{.spec.namespaceSelector}'
+----
+
+. **VM Fails with "failed bridge mapping validation"**:
+   * **Symptom**: VM pod fails even though CUDN exists
+   * **Cause**: `physicalNetworkName` in CUDN doesn't match bridge mapping logical name
+   * **Solution**: Ensure they match exactly (case-sensitive)
++
+[source,bash,role=execute]
+----
+# Compare the names
+oc get clusteruserdefinednetwork <cudn-name> -o jsonpath='{.spec.network.localnet.physicalNetworkName}'
+oc get nncp <bridge-mapping-nncp> -o jsonpath='{.spec.desiredState.ovn.bridge-mappings[0].localnet}'
+----
+
+. **IPAM Mode Issues**:
+   * **Symptom**: VMs not getting expected IP addresses
+   * **Cause**: IPAM mode misconfigured or cloud-init not working
+   * **For Static IP via cloud-init**: Set `ipam.mode: Disabled` in CUDN
+   * **For OVN IPAM**: Set `ipam.mode: Static` with `staticIPAMConfig`
+   * **Verification**:
++
+[source,bash,role=execute]
+----
+# Check IPAM mode
+oc get clusteruserdefinednetwork <cudn-name> -o jsonpath='{.spec.network.localnet.ipam.mode}'
+
+# Check cloud-init logs in VM
+virtctl console -n <namespace> <vm-name>
+# Inside VM: cat /var/log/cloud-init.log
+----
+
+== Localnet VLAN Network Troubleshooting
+
+=== Common Issues
+
+. **VLAN Traffic Not Reaching VM**:
+   * Verify physical switch configuration supports VLAN tagging
+   * Check bridge mapping configuration on worker nodes
+   * Ensure VLAN ID matches network infrastructure
+   * Verify the physical NIC is connected and UP
+   * Check that the OVS bridge includes the physical interface as a port
+
+. **IP Address Assignment Issues**:
+   * Verify DHCP server is available on the VLAN network
+
+. **Network Connectivity Problems**:
+   * Check that the physical network supports the configured VLAN
+   * Test connectivity from physical network to VLAN subnet
+   * Verify the physical switch port is in trunk mode
+
+. **Custom Bridge Creation Issues**:
+   * Remember: OVS bridges won't show in `ip addr show` - use `ovs-vsctl list-br` instead
+   * Ensure the physical interface name is correct
+   * Verify NMState operator is running properly
+
+. **Bridge Mapping Not Working**:
+   * Verify the bridge name in the mapping matches the created bridge
+   * Check OVN bridge mappings: `ovs-vsctl get Open_vSwitch . external_ids:ovn-bridge-mappings`
+   * Ensure the localnet name in the mapping matches the NAD configuration
+
+. **VM Pod Fails with "failed bridge mapping validation" Error**:
+   * **Symptom**: VM pod fails with error: `failed to find OVN bridge-mapping for network: "localnet-vlan-100"`
+   * **Cause**: Missing `physicalNetworkName` parameter in NetworkAttachmentDefinition
+   * **Solution**: Ensure NAD includes `"physicalNetworkName": "localnet-vlan"` that matches the bridge mapping logical name from bridge mapping configuration
+   * **Verification**: After updating NAD, recreate it with `oc delete` and `oc apply`
+
+=== Verification Commands
+
+[source,bash,role=execute]
+----
+# Check NetworkAttachmentDefinition status
+oc get network-attachment-definitions -n vm-guests-vlan
+
+# Verify all NodeNetworkConfigurationPolicies
+oc get nncp
+
+# Check bridge creation status (if using custom bridge)
+oc get nncp br-vlan-creation -o yaml
+
+# Verify bridge mapping on worker nodes
+oc get nncp localnet-vlan-bridge-mapping -o yaml
+
+# Check physical interface status on worker node
+oc debug node/<worker-node-name> -- chroot /host ip link show ens224
+
+# Verify OVS bridge configuration
+oc debug node/<worker-node-name> -- chroot /host ovs-vsctl show
+
+# Check OVN bridge mappings
+oc debug node/<worker-node-name> -- chroot /host ovs-vsctl get Open_vSwitch . external_ids:ovn-bridge-mappings
+
+# List all ports on the custom bridge
+oc debug node/<worker-node-name> -- chroot /host ovs-vsctl list-ports br-vlan
+
+# Check VM network status
+oc get vmi -n vm-guests-vlan -o yaml | grep -A 10 networks
+
+# View OVN-Kubernetes logs for troubleshooting
+oc logs -n openshift-ovn-kubernetes -l app=ovnkube-node
+
+# Check NMState operator logs if bridge creation fails
+oc logs -n openshift-nmstate -l app=kubernetes-nmstate-operator
+----
+
+== References
+
+* link:https://nmstate.io/[NMState Documentation,window=_blank]
+* link:http://www.openvswitch.org/support/dist-docs/[Open vSwitch Documentation,window=_blank]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator[OpenShift NMState Operator,window=_blank]

--- a/modules/networking/pages/udn-primary-networks.adoc
+++ b/modules/networking/pages/udn-primary-networks.adoc
@@ -1,0 +1,196 @@
+= Configuring Layer 2 Primary Networks with UDNs
+:navtitle: UDN Primary Networks
+
+== Overview
+
+This tutorial shows you how to create a primary network using User Defined Networks (UDNs) with Layer 2 topology in OpenShift Virtualization. Instead of using the cluster's default network, UDNs let you define custom IP ranges and provide complete network isolation for applications within a specific namespace. This approach is ideal when applications need direct control over IP addressing or require custom networking requirements. The entire setup takes just 5 straightforward steps without requiring additional network attachment definitions.
+
+Versions tested:
+----
+OCP 4.19
+----
+
+== Step 1: Create UDN-Enabled Namespace
+
+Create a namespace with the UDN primary network label to enable User Defined Network functionality. The special label `k8s.ovn.org/primary-user-defined-network` tells OpenShift that this namespace will use a custom primary network instead of the cluster default.
+
+NOTE: The namespace must be created and labeled before any workload deployment happens and cannot be changed once created.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: udn-primary-vm-guests
+  labels:
+    k8s.ovn.org/primary-user-defined-network: ""
+EOF
+----
+
+== Step 2: Configure the UserDefinedNetwork Resource
+
+Define the primary UDN with Layer2 topology and custom subnet configuration. This resource specifies the network characteristics including IP range, IPAM lifecycle, and primary role designation to override default cluster networking for pods in the namespace.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: k8s.ovn.org/v1
+kind: UserDefinedNetwork
+metadata:
+  name: udn-primary
+  namespace: udn-primary-vm-guests
+spec:
+  topology: Layer2
+  layer2:
+    role: Primary
+    subnets: 
+    - "192.168.100.0/24"
+  ipam:
+    lifecycle: Persistent
+EOF
+----
+
+== Step 3: Deploy Workload with Primary UDN
+
+Create a virtual machine that utilizes the primary UDN configuration and runs a simple Python HTTP server for testing connectivity. The workload automatically receives an IP address from the 192.168.100.0/24 subnet via the UDN's IPAM and uses the UDN as its primary network interface.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora-vm-with-udn
+  namespace: udn-primary-vm-guests
+  labels:
+    app: fedora-web-vm
+    network-type: udn-primary
+spec:
+  running: true
+  dataVolumeTemplates:
+  - metadata:
+      name: fedora-udn-volume
+    spec:
+      pvc:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 33Gi
+      sourceRef:
+        kind: DataSource
+        name: fedora
+        namespace: openshift-virtualization-os-images
+  template:
+    metadata:
+      labels:
+        app: fedora-web-vm
+    spec:
+      domain:
+        devices:
+          disks:
+          - name: datavolumedisk
+            disk:
+              bus: virtio
+          - name: cloudinitdisk
+            disk:
+              bus: virtio
+          interfaces:
+          - name: default
+            binding:
+              name: l2bridge
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 1
+      networks:
+      - name: default
+        pod: {}
+      volumes:
+      - name: datavolumedisk
+        dataVolume:
+          name: fedora-udn-volume
+      - name: cloudinitdisk
+        cloudInitNoCloud:          
+          userData: |
+            #cloud-config
+            write_files:
+            - path: /etc/resolv.conf
+              content: |
+                nameserver 172.30.0.10      # cluster DNS
+                search udn-primary-vm-guests.svc.cluster.local svc.cluster.local
+                options ndots:5            
+            user: fedora
+            password: fedora
+            chpasswd: { expire: False }
+            packages:
+            - python3
+            runcmd:
+            - echo "<h1>Welcome to OpenShift Virtualization !!!</h1>" > /root/index.html
+            - cd /root && nohup python3 -m http.server 80 > /dev/null 2>&1 &
+EOF
+----
+
+== Step 4: Expose VM as a Service
+
+Create a Kubernetes Service to expose the VM's Python HTTP server with a LoadBalancer.
+
+NOTE: Cloud services like AWS automatically deploy a load balancer for this configuration. For bare metal deployments, consider using link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/ingress_and_load_balancing/load-balancing-with-metallb[MetalLB,window=_blank] as your load balancer.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: fedora-vm-web-service
+  namespace: udn-primary-vm-guests
+  labels:
+    app: fedora-web-vm
+spec:
+  selector:
+    app: fedora-web-vm
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+    protocol: TCP
+  type: LoadBalancer
+EOF
+----
+
+== Step 5: Verify Service Availability
+
+This test was performed using an AWS-based cluster with metal type instances that automatically deploys a load balancer and creates an external name. You can find the name in the external service IP:
+
+[source,bash,role=execute]
+----
+oc get svc
+----
+
+Example output:
+----
+NAME                    TYPE           CLUSTER-IP      EXTERNAL-IP                                                                  PORT(S)        AGE
+fedora-vm-web-service   LoadBalancer   172.30.72.140   aa32981df19ad4959ae9a82fb9990db9-1996929606.ca-central-1.elb.amazonaws.com   80:32291/TCP   45m
+----
+
+Test the service using curl:
+
+[source,bash,role=execute]
+----
+curl aa32981df19ad4959ae9a82fb9990db9-1996929606.ca-central-1.elb.amazonaws.com
+----
+
+Expected output:
+----
+<h1>Welcome to OpenShift Virtualization !!!</h1>
+----
+
+== References
+
+=== OpenShift Documentation
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/multiple_networks/understanding-multiple-networks[OpenShift - Understanding Multiple Networks,window=_blank]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/multiple_networks/primary-networks[Configuring Primary Networks,window=_blank]
+

--- a/modules/storage/nav.adoc
+++ b/modules/storage/nav.adoc
@@ -1,0 +1,3 @@
+* xref:index.adoc[Storage Configuration]
+** xref:lvm-operator.adoc[LVM Operator Installation]
+** xref:lvm-troubleshooting.adoc[LVM Troubleshooting]

--- a/modules/storage/pages/index.adoc
+++ b/modules/storage/pages/index.adoc
@@ -1,0 +1,69 @@
+= Storage Configuration
+:navtitle: Storage
+
+== Overview
+
+This module covers storage configuration for OpenShift Virtualization, including installation and configuration of the LVM Storage operator and troubleshooting storage issues.
+
+Proper storage configuration is essential for virtual machine deployments, as VMs require persistent storage for their disks and data.
+
+== What You'll Learn
+
+In this section, you will learn:
+
+* How to install and configure the LVM Storage operator for local disk storage
+* How to set a default storage class for automatic provisioning
+* How to troubleshoot common LVM storage issues
+* Best practices for storage configuration in OpenShift Virtualization
+
+== Storage Options for OpenShift Virtualization
+
+OpenShift Virtualization supports various storage backends:
+
+* **LVM Storage**: Local disk storage using Logical Volume Manager (covered in this module)
+* **Ceph/ODF**: Distributed block and file storage
+* **HostPath Provisioner**: Simple local storage provisioning
+* **NFS**: Network-attached storage
+* **External storage providers**: AWS EBS, Azure Disk, etc.
+
+This module focuses on LVM Storage, which is ideal for Single Node OpenShift (SNO) and bare-metal deployments with local disks.
+
+== Prerequisites
+
+Before proceeding with the tutorials in this section, ensure you have:
+
+* OpenShift 4.14+ cluster
+* Cluster admin access
+* At least one spare local disk on cluster nodes
+* Basic understanding of Linux storage concepts (LVM, block devices)
+
+== Sections
+
+xref:lvm-operator.adoc[LVM Storage Operator Installation]::
+Step-by-step guide to install and configure the LVM Storage operator with a local disk.
+
+xref:lvm-troubleshooting.adoc[LVM Storage Troubleshooting]::
+Comprehensive troubleshooting guide for diagnosing and resolving LVM storage issues.
+
+== Why Default Storage Class Matters
+
+Setting a default storage class is critical for OpenShift Virtualization:
+
+* **Boot Source Images**: DataSource OS images require a default storage class
+* **Automatic Provisioning**: VMs can be created without explicitly specifying storage
+* **Template Support**: VM templates work out-of-the-box
+* **Simplified Operations**: Consistent storage provisioning across the cluster
+
+See xref:lvm-operator.adoc#_step_5_set_default_storageclass[Step 5: Set Default StorageClass] in the LVM operator guide for details.
+
+== Next Steps
+
+After completing this module, you'll be ready to:
+
+* xref:networking:index.adoc[Configure networking] for your VMs
+* Create and configure virtual machines
+
+== See Also
+
+* xref:getting-started:storage-setup.adoc[Configure Default Storage Class]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/storage/persistent-storage-using-local-storage#persistent-storage-using-lvms[OpenShift LVM Storage Documentation,window=_blank]

--- a/modules/storage/pages/lvm-operator.adoc
+++ b/modules/storage/pages/lvm-operator.adoc
@@ -1,0 +1,547 @@
+= Installing LVM Storage Operator
+:navtitle: LVM Operator
+
+== Overview
+
+This tutorial demonstrates how to install and configure the LVM Storage operator to use a spare local disk on OpenShift nodes. The LVM operator provides dynamic storage provisioning using Logical Volume Manager, ideal for Single Node OpenShift (SNO) or bare-metal clusters with local storage.
+
+== Prerequisites
+
+* **OpenShift 4.14+**: LVM Storage operator is supported
+* **Local disk available**: At least one spare disk on cluster nodes
+* **Cluster admin access**: Required to install operators and create storage classes
+* **Disk can have existing data**: The operator can force-wipe disks using the `forceWipeDevicesAndDestroyAllData` parameter
+
+Versions tested:
+----
+OCP 4.19
+----
+
+== Important Warning
+
+NOTE: Using the `forceWipeDevicesAndDestroyAllData: true` parameter will permanently destroy all data on the specified disk. Ensure you have backups and are using the correct disk device path before proceeding.
+
+== Step 1: Identify Available Disks
+
+Before configuring the LVM operator, identify which disk you want to use for storage.
+
+[source,bash,role=execute]
+----
+# Get your node name
+oc get nodes
+
+# List all block devices on the node
+oc debug node/<node-name> -- chroot /host lsblk -o NAME,SIZE,TYPE,FSTYPE,MOUNTPOINT,MODEL
+----
+
+Example output:
+----
+NAME    SIZE TYPE FSTYPE      MOUNTPOINT MODEL
+sda   558.4G disk LVM2_member            PERC H730 Adp
+sdc   558.4G disk                        PERC H730 Adp
+|-sdc1   1M part                        
+|-sdc2 127M part vfat                   
+|-sdc3 384M part ext4        /boot      
+`-sdc4 557.9G part xfs        /sysroot
+----
+
+In this example:
+
+* `sda` - Spare disk with existing LVM data (this will be our target)
+* `sdc` - System disk with OS partitions (DO NOT USE)
+
+Check for existing LVM usage:
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host pvs
+----
+
+Example output:
+----
+PV         VG  Fmt  Attr PSize   PFree  
+/dev/sda   vg1 lvm2 a--  558.37g <55.84g
+----
+
+This shows `/dev/sda` has existing LVM configuration that will be wiped when using `forceWipeDevicesAndDestroyAllData: true`.
+
+Get disk device path for persistent identification:
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host ls -la /dev/disk/by-path/ | grep -E "pci.*scsi"
+----
+
+Example output:
+----
+lrwxrwxrwx. 1 root root 9 Oct 6 13:30 pci-0000:03:00.0-scsi-0:2:1:0 -> ../../sda
+----
+
+The persistent path `/dev/disk/by-path/pci-0000:03:00.0-scsi-0:2:1:0` points to `/dev/sda`.
+
+== Step 2: Install LVM Storage Operator
+
+Create the namespace and install the LVM Storage operator.
+
+Create namespace for LVM operator:
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-storage
+EOF
+----
+
+Create OperatorGroup:
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-storage-operatorgroup
+  namespace: openshift-storage
+spec:
+  targetNamespaces:
+  - openshift-storage
+EOF
+----
+
+Create Subscription to install the operator:
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: lvms-operator
+  namespace: openshift-storage
+spec:
+  channel: stable-4.19
+  name: lvms-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+EOF
+----
+
+Verify operator installation:
+
+[source,bash,role=execute]
+----
+# Wait for the operator to be installed (may take 2-3 minutes)
+oc get csv -n openshift-storage
+
+# Check operator pod is running
+oc get pods -n openshift-storage
+----
+
+Expected output (after operator installation, before LVMCluster):
+----
+NAME                             READY   STATUS    RESTARTS   AGE
+lvms-operator-864b6975bb-kxt4t   1/1     Running   0          2m
+----
+
+NOTE: At this stage, you should only see the `lvms-operator` pod. The `vg-manager` pod will be created automatically after you create the LVMCluster resource in Step 3.
+
+Expected output (after LVMCluster is created in Step 3):
+----
+NAME                                  READY   STATUS    RESTARTS   AGE
+lvms-operator-864b6975bb-kxt4t        1/1     Running   0          5m
+vg-manager-xxxxx                      1/1     Running   0          1m
+----
+
+== Step 3: Create LVMCluster Configuration
+
+Create an LVMCluster resource to configure the LVM storage backend. This is where you specify which disk to use and whether to force-wipe existing data.
+
+=== Configuration for Disk with Existing Data
+
+If your disk has existing data or partitions (like our `sda` example), use `forceWipeDevicesAndDestroyAllData: true`:
+
+NOTE: Using `forceWipeDevicesAndDestroyAllData: true` will permanently destroy all data on the specified disk. Ensure you have backups and are using the correct disk device path before proceeding.
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: lvm.topolvm.io/v1alpha1
+kind: LVMCluster
+metadata:
+  name: lvmcluster
+  namespace: openshift-storage
+spec:
+  storage:
+    deviceClasses:
+    - name: vg1
+      default: true
+      thinPoolConfig:
+        name: thin-pool-1
+        sizePercent: 90
+        overprovisionRatio: 10
+      nodeSelector:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: node-role.kubernetes.io/worker
+            operator: In
+            values:
+            - ""
+      deviceSelector:
+        paths:
+        - /dev/sda
+        forceWipeDevicesAndDestroyAllData: true
+EOF
+----
+
+=== Configuration for Clean/New Disk
+
+If your disk is clean with no existing data or partitions:
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: lvm.topolvm.io/v1alpha1
+kind: LVMCluster
+metadata:
+  name: lvmcluster
+  namespace: openshift-storage
+spec:
+  storage:
+    deviceClasses:
+    - name: vg1
+      default: true
+      thinPoolConfig:
+        name: thin-pool-1
+        sizePercent: 90
+        overprovisionRatio: 10
+      nodeSelector:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: node-role.kubernetes.io/worker
+            operator: In
+            values:
+            - ""
+      deviceSelector:
+        paths:
+        - /dev/sda
+EOF
+----
+
+=== Configuration Parameters Explained
+
+* **`name: vg1`**: Volume group name (will be created on the disk)
+* **`default: true`**: Makes this deviceClass the default for the cluster
+  ** **Purpose**: Prevents warning about no default deviceClass
+  ** **Effect**: The generated StorageClass will be available without explicitly specifying it in PVCs
+  ** **Note**: If you have multiple deviceClasses, only one should be marked as default
+* **`thinPoolConfig`**: Configures thin provisioning for efficient storage use
+  ** `sizePercent: 90`: Use 90% of disk space for the thin pool
+  ** `overprovisionRatio: 10`: Allow 10x overprovisioning (provision more storage than physically available)
+* **`nodeSelector`**: Which nodes to configure (worker nodes in this example)
+* **`deviceSelector.paths`**: Specific disk device paths to use
+  ** Can use `/dev/sda`, `/dev/disk/by-path/...`, or `/dev/disk/by-id/...`
+* **`forceWipeDevicesAndDestroyAllData: true`**: CRITICAL PARAMETER
+  ** **Purpose**: Wipes all existing data and partitions on the disk
+  ** **Use when**: Disk has existing filesystems, partitions, or LVM configuration
+  ** **Effect**: Complete data destruction - no recovery possible
+  ** **Omit when**: Disk is already clean/empty
+
+== Step 4: Verify LVMCluster Status
+
+Run a quick health check to verify the LVMCluster is ready:
+
+[source,bash,role=execute]
+----
+# Check LVMCluster status
+oc get lvmcluster -n openshift-storage
+
+# Verify volume group was created
+oc debug node/<node-name> -- chroot /host vgs
+
+# Verify thin pool was created
+oc debug node/<node-name> -- chroot /host lvs
+----
+
+Expected healthy output:
+
+* LVMCluster shows `STATUS: Ready`
+* VG `vg1` appears with appropriate size
+* Thin pool `thin-pool-1` is active with low data/meta usage
+
+For detailed verification steps, expected outputs, and troubleshooting, see the xref:lvm-troubleshooting.adoc[LVM Storage Troubleshooting Guide].
+
+[[_step_5_set_default_storageclass]]
+== Step 5: Set Default StorageClass
+
+The LVM operator automatically creates a StorageClass named `lvms-vg1`, but it does not set it as the default. Making it the default StorageClass is essential for OpenShift Virtualization to automatically provision storage for VM disks and DataVolumes.
+
+=== Verify StorageClass Exists
+
+[source,bash,role=execute]
+----
+oc get storageclass
+----
+
+Expected output:
+----
+NAME       PROVISIONER   RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+lvms-vg1   topolvm.io    Delete          WaitForFirstConsumer   true                   5m
+----
+
+NOTE: No `(default)` annotation is shown - this StorageClass is not yet the default.
+
+=== Set as Default StorageClass
+
+Make the LVM StorageClass the default for the cluster:
+
+[source,bash,role=execute]
+----
+oc patch storageclass lvms-vg1 -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+----
+
+=== Verify Default Status
+
+[source,bash,role=execute]
+----
+oc describe sc | grep IsDefaultClass
+----
+
+Expected output after setting default:
+----
+NAME                 PROVISIONER   RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+lvms-vg1 (default)   topolvm.io    Delete          WaitForFirstConsumer   true                   6m
+----
+
+The `(default)` annotation confirms this is now the default StorageClass.
+
+=== Why This is Important for OpenShift Virtualization
+
+Setting a default StorageClass is critical for OpenShift Virtualization:
+
+==== DataSource OS Images Require Default Storage
+
+OpenShift Virtualization's DataSource OS images (Fedora, RHEL, CentOS Stream, Windows) need a default StorageClass to automatically create boot source volumes:
+
+[source,bash,role=execute]
+----
+# Check available OS images
+oc get datasources -n openshift-virtualization-os-images
+----
+
+Without a default StorageClass, these DataSources will remain in a pending state and cannot be used for VM creation.
+
+==== Automatic PVC Creation for VMs
+
+When creating VMs using `dataVolumeTemplates`, if no `storageClassName` is specified, the default StorageClass is used:
+
+[source,yaml]
+----
+dataVolumeTemplates:
+- metadata:
+    name: fedora-volume
+  spec:
+    pvc:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 30Gi
+    sourceRef:
+      kind: DataSource
+      name: fedora
+      namespace: openshift-virtualization-os-images
+----
+
+This automatically uses the default StorageClass (`lvms-vg1`) without explicitly specifying it.
+
+==== Simplified VM Creation
+
+With a default StorageClass:
+
+* VM templates work out-of-the-box
+* DataSource cloning happens automatically
+* No need to specify `storageClassName` in every PVC
+* Consistent storage provisioning across the cluster
+
+==== Boot Source Preparation
+
+The OpenShift Virtualization operator can automatically prepare boot sources for common OS images when a default StorageClass is available:
+
+[source,bash,role=execute]
+----
+# Check boot source preparation status
+oc get DataImportCron -n openshift-virtualization-os-images
+----
+
+=== Alternative: Explicit StorageClass in VMs
+
+If you choose not to set a default StorageClass, you must explicitly specify it in every VM definition:
+
+[source,yaml]
+----
+dataVolumeTemplates:
+- metadata:
+    name: fedora-volume
+  spec:
+    pvc:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 30Gi
+      storageClassName: lvms-vg1  # Must be explicit
+    sourceRef:
+      kind: DataSource
+      name: fedora
+      namespace: openshift-virtualization-os-images
+----
+
+NOTE: Always set a default StorageClass for OpenShift Virtualization clusters to simplify operations and enable automatic boot source provisioning.
+
+== Step 6: Test Storage Provisioning
+
+Create a test PVC to verify storage provisioning works:
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lvms-test-pvc
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: lvms-vg1
+EOF
+----
+
+Create a test pod to use the PVC:
+
+[source,yaml]
+----
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lvms-test-pod
+  namespace: default
+spec:
+  containers:
+  - name: test
+    image: registry.access.redhat.com/ubi9/ubi:latest
+    command: ["sleep", "3600"]
+    volumeMounts:
+    - name: data
+      mountPath: /data
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: lvms-test-pvc
+EOF
+----
+
+Verify PVC is bound:
+
+[source,bash,role=execute]
+----
+oc get pvc lvms-test-pvc
+
+# Should show STATUS as "Bound"
+----
+
+Verify pod is running and can write to storage:
+
+[source,bash,role=execute]
+----
+# Wait for pod to start
+oc wait --for=condition=Ready pod/lvms-test-pod --timeout=120s
+
+# Test writing to the volume
+oc exec lvms-test-pod -- sh -c "echo 'LVM Storage Test' > /data/test.txt && cat /data/test.txt"
+
+# Expected output: LVM Storage Test
+----
+
+Clean up test resources:
+
+[source,bash,role=execute]
+----
+oc delete pod lvms-test-pod
+oc delete pvc lvms-test-pvc
+----
+
+== Troubleshooting
+
+If you encounter any issues during installation or operation of LVM storage, refer to the comprehensive xref:lvm-troubleshooting.adoc[LVM Storage Troubleshooting Guide].
+
+The troubleshooting guide covers:
+
+* Complete verification commands with expected outputs
+* Common issues and their solutions
+* Device discovery and wipe problems
+* PVC provisioning issues
+* Thin pool management
+* Comprehensive diagnostic procedures
+
+== Understanding forceWipeDevicesAndDestroyAllData
+
+=== What It Does
+
+The `forceWipeDevicesAndDestroyAllData: true` parameter:
+
+. **Removes partition tables**: Wipes GPT, MBR, and any partition information
+. **Destroys filesystems**: Removes ext4, xfs, btrfs, and other filesystem signatures
+. **Clears LVM metadata**: Removes existing physical volumes, volume groups, and logical volumes
+. **Zeroes beginning of disk**: Writes zeros to the first few megabytes to ensure clean state
+. **Forces reuse**: Allows the LVM operator to take ownership of the disk
+
+=== When to Use It
+
+Use `forceWipeDevicesAndDestroyAllData: true` when:
+
+* Disk has existing partitions or filesystems
+* Disk was previously used for LVM (has PV/VG/LV)
+* Disk has data you want to destroy
+* You're repurposing a disk from another use case
+
+Don't use it when:
+
+* Disk is brand new and unformatted
+* You're unsure which disk to use (verify first!)
+* Disk contains data you need to keep
+
+=== Safety Checks Before Using
+
+Always verify the disk device path before enabling this parameter:
+
+[source,bash,role=execute]
+----
+# 1. Verify the disk path
+oc debug node/<node-name> -- chroot /host lsblk -o NAME,SIZE,TYPE,MOUNTPOINT
+
+# 2. Ensure disk is NOT mounted
+oc debug node/<node-name> -- chroot /host mount | grep /dev/sda
+
+# 3. Double-check you're not using the system disk
+oc debug node/<node-name> -- chroot /host df -h | grep sda
+
+# 4. Review disk serial number
+oc debug node/<node-name> -- chroot /host lsblk -d -o NAME,SERIAL /dev/sda
+----
+
+== References
+
+=== OpenShift Documentation
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/storage/persistent-storage-using-local-storage#persistent-storage-using-lvms[Persistent Storage Using LVM Storage,window=_blank]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/storage/understanding-persistent-storage#storage-classes_understanding-persistent-storage[Understanding Persistent Storage,window=_blank]
+

--- a/modules/storage/pages/lvm-troubleshooting.adoc
+++ b/modules/storage/pages/lvm-troubleshooting.adoc
@@ -1,0 +1,782 @@
+= Troubleshooting LVM Storage Operator
+:navtitle: LVM Troubleshooting
+
+== Overview
+
+This guide provides comprehensive troubleshooting steps for the LVM Storage operator in OpenShift. Use these commands to diagnose and resolve common issues with LVM storage provisioning, volume groups, and persistent volume claims.
+
+== Quick Health Check
+
+Run this comprehensive health check to verify your LVM storage is working correctly:
+
+[source,bash,role=execute]
+----
+# 1. Check LVMCluster status
+oc get lvmcluster -n openshift-storage
+
+# 2. Check all pods are running
+oc get pods -n openshift-storage
+
+# 3. Check StorageClass exists
+oc get storageclass | grep lvms
+
+# 4. Check volume group on node
+oc debug node/<node-name> -- chroot /host vgs
+
+# 5. Check thin pool
+oc debug node/<node-name> -- chroot /host lvs
+----
+
+Expected healthy output:
+
+* LVMCluster: `STATUS: Ready`
+* Pods: All `Running` with no restarts
+* StorageClass: `lvms-vg1` exists
+* VG: Shows volume group with available space
+* LV: Shows thin pool with low data/meta usage
+
+== Verification Commands by Component
+
+=== LVMCluster Status
+
+==== Check Basic Status
+
+[source,bash,role=execute]
+----
+oc get lvmcluster -n openshift-storage
+----
+
+Healthy output:
+----
+NAME         STATUS
+lvmcluster   Ready
+----
+
+Unhealthy indicators:
+
+* Status shows `NotReady`, `Degraded`, or `Error`
+* No resources found
+
+==== Check Detailed Status
+
+[source,bash,role=execute]
+----
+oc get lvmcluster lvmcluster -n openshift-storage -o yaml
+----
+
+What to look for:
+
+[source,yaml]
+----
+status:
+  conditions:
+  - status: "True"
+    type: ResourcesAvailable
+    message: Reconciliation is complete and all the resources are available
+  - status: "True"
+    type: VolumeGroupsReady
+    message: All the VGs are ready
+  deviceClassStatuses:
+  - name: vg1
+    nodeStatus:
+    - devices:
+      - /dev/sda
+      status: Ready
+  ready: true
+  state: Ready
+----
+
+Key fields:
+
+* `status.conditions`: Should show `ResourcesAvailable: True` and `VolumeGroupsReady: True`
+* `deviceClassStatuses[].nodeStatus[].status`: Should be `Ready`
+* `deviceClassStatuses[].nodeStatus[].devices`: Should list your configured disk
+* `ready: true` and `state: Ready`
+
+==== View Device Discovery and Exclusions
+
+[source,bash,role=execute]
+----
+oc get lvmcluster lvmcluster -n openshift-storage -o yaml | grep -A 50 "deviceClassStatuses"
+----
+
+Example output:
+
+[source,yaml]
+----
+deviceClassStatuses:
+- name: vg1
+  nodeStatus:
+  - devices:
+    - /dev/sda
+    excluded:
+    - name: /dev/sdc
+      reasons:
+      - /dev/sdc has children block devices and could not be considered
+      - /dev/sdc is not part of the device selector
+    status: Ready
+----
+
+This shows which devices were selected and why others were excluded.
+
+=== Pod Status
+
+==== Check All Pods
+
+[source,bash,role=execute]
+----
+oc get pods -n openshift-storage
+----
+
+Healthy output:
+----
+NAME                             READY   STATUS    RESTARTS   AGE
+lvms-operator-864b6975bb-kxt4t   1/1     Running   0          10m
+vg-manager-xxxxx                 1/1     Running   0          5m
+----
+
+Expected pods:
+
+* **lvms-operator**: Always present, manages the lifecycle of LVM storage
+* **vg-manager**: One per node, manages volume groups on that node
+* **topolvm-controller**: May not be present on Single Node OpenShift (SNO)
+
+==== Check Pod Details
+
+[source,bash,role=execute]
+----
+# Get pod details
+oc describe pod -n openshift-storage <pod-name>
+
+# Check specific pod logs
+oc logs -n openshift-storage <pod-name>
+
+# Check vg-manager logs (most useful for device issues)
+oc logs -n openshift-storage daemonset/vg-manager
+----
+
+Common log errors:
+
+* `"device is in use"` - Disk already mounted or used by system
+* `"cannot wipe device"` - Need `forceWipeDevicesAndDestroyAllData: true`
+* `"device not found"` - Wrong device path specified
+* `"no devices found"` - Device selector doesn't match any available devices
+
+==== Check Operator Installation
+
+[source,bash,role=execute]
+----
+# Check ClusterServiceVersion
+oc get csv -n openshift-storage
+
+# Check subscription
+oc get subscription -n openshift-storage
+
+# Check install plan
+oc get installplan -n openshift-storage
+----
+
+=== Storage Resources
+
+==== Check StorageClass
+
+[source,bash,role=execute]
+----
+# List all StorageClasses
+oc get storageclass
+
+# Get specific LVM StorageClass
+oc get storageclass lvms-vg1 -o yaml
+----
+
+Healthy output:
+----
+NAME       PROVISIONER   RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+lvms-vg1   topolvm.io    Delete          WaitForFirstConsumer   true                   10m
+----
+
+Key parameters:
+
+* `PROVISIONER: topolvm.io` - Correct provisioner
+* `VOLUMEBINDINGMODE: WaitForFirstConsumer` - Efficient binding
+* `ALLOWVOLUMEEXPANSION: true` - Volume expansion enabled
+
+==== Check if StorageClass is Default
+
+[source,bash,role=execute]
+----
+oc get storageclass lvms-vg1 -o jsonpath='{.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}'
+----
+
+Output:
+
+* `true` - This is the default StorageClass
+* No output or `false` - Not the default
+
+==== Check PersistentVolumes
+
+[source,bash,role=execute]
+----
+# List all PVs
+oc get pv
+
+# Check PVs using LVM storage
+oc get pv | grep topolvm
+----
+
+=== Volume Group Verification
+
+==== Check Volume Group Status
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host vgs
+----
+
+Healthy output:
+----
+VG   #PV #LV #SN Attr   VSize   VFree  
+vg1    1   1   0 wz--n- 558.37g <55.84g
+----
+
+What to verify:
+
+* VG name matches your LVMCluster configuration (e.g., `vg1`)
+* `VSize` shows total disk size
+* `VFree` shows available space
+* `Attr` should include `wz--n-` (writeable, resizable, normal)
+
+==== Check Volume Group Details
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host vgdisplay vg1
+----
+
+Example output:
+----
+--- Volume group ---
+VG Name               vg1
+System ID             
+Format                lvm2
+Metadata Areas        1
+Metadata Sequence No  2
+VG Access             read/write
+VG Status             resizable
+MAX LV                0
+Cur LV                1
+Open LV               0
+Max PV                0
+Cur PV                1
+Act PV                1
+VG Size               558.37 GiB
+PE Size               4.00 MiB
+Total PE              142942
+Alloc PE / Size       128517 / 502.04 GiB
+Free  PE / Size       14425 / 56.35 GiB
+VG UUID               abc123...
+----
+
+Key indicators of health:
+
+* `VG Status: resizable`
+* `VG Access: read/write`
+* `Free PE / Size` shows available space
+
+=== Thin Pool Verification
+
+==== Check Thin Pool Status
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host lvs
+----
+
+Healthy output:
+----
+LV          VG  Attr       LSize    Pool Origin Data%  Meta%  
+thin-pool-1 vg1 twi-a-tz-- <502.04g             0.00   6.76
+----
+
+Attribute breakdown (twi-a-tz--):
+
+* `t` - thin pool
+* `w` - writeable
+* `i` - inherited
+* `a` - active
+* `t` - thin
+* `z` - zero
+
+Data% and Meta% thresholds:
+
+* **Data%**: Shows how much thin pool data is used
+  ** `< 80%` - Healthy
+  ** `80-90%` - Monitor closely
+  ** `> 90%` - Consider expanding or cleaning up
+* **Meta%**: Shows metadata usage
+  ** `< 80%` - Healthy
+  ** `> 80%` - May need metadata expansion
+
+==== Check Thin Pool Details
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host lvdisplay vg1/thin-pool-1
+----
+
+=== Physical Volume Verification
+
+==== Check Physical Volume
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host pvs
+----
+
+Healthy output:
+----
+PV         VG  Fmt  Attr PSize   PFree  
+/dev/sda   vg1 lvm2 a--  558.37g <55.84g
+----
+
+Attribute breakdown (a--):
+
+* `a` - allocatable
+* `-` - not exported
+* `-` - not missing
+
+==== Check Physical Volume Details
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host pvdisplay /dev/sda
+----
+
+==== Verify Device Path
+
+[source,bash,role=execute]
+----
+# Check device exists
+oc debug node/<node-name> -- chroot /host ls -la /dev/sda
+
+# Check device is a block device
+oc debug node/<node-name> -- chroot /host lsblk /dev/sda
+
+# Check device is not mounted
+oc debug node/<node-name> -- chroot /host mount | grep /dev/sda
+----
+
+NOTE: If device is mounted, it cannot be used for LVM storage. Unmount or choose a different device.
+
+=== Disk and Device Information
+
+==== List All Block Devices
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host lsblk -o NAME,SIZE,TYPE,FSTYPE,MOUNTPOINT,MODEL
+----
+
+Example output:
+----
+NAME    SIZE TYPE FSTYPE      MOUNTPOINT MODEL
+sda   558.4G disk LVM2_member            PERC H730 Adp
+sdc   558.4G disk                        PERC H730 Adp
+|-sdc1   1M part                        
+|-sdc2 127M part vfat                   
+|-sdc3 384M part ext4        /boot      
+`-sdc4 557.9G part xfs        /sysroot
+----
+
+How to identify usable disks:
+
+* No MOUNTPOINT - disk not in use
+* No FSTYPE or shows `LVM2_member` (if wiping is intended)
+* Has MOUNTPOINT - disk in use by system
+* Has partitions (children) - may need wiping
+
+==== Check Disk Serial Numbers
+
+[source,bash,role=execute]
+----
+oc debug node/<node-name> -- chroot /host lsblk -d -o NAME,SIZE,SERIAL
+----
+
+Use this to ensure you're targeting the correct disk.
+
+==== Check Device Persistent Paths
+
+[source,bash,role=execute]
+----
+# By path
+oc debug node/<node-name> -- chroot /host ls -la /dev/disk/by-path/ | grep sda
+
+# By ID
+oc debug node/<node-name> -- chroot /host ls -la /dev/disk/by-id/ | grep sda
+----
+
+== Common Issues and Solutions
+
+=== Issue 1: LVMCluster Shows "NotReady"
+
+Symptoms:
+----
+NAME         STATUS
+lvmcluster   NotReady
+----
+
+Diagnosis:
+
+[source,bash,role=execute]
+----
+# Check detailed status
+oc get lvmcluster lvmcluster -n openshift-storage -o yaml | grep -A 20 "conditions"
+
+# Check vg-manager logs
+oc logs -n openshift-storage daemonset/vg-manager
+----
+
+Common causes and solutions:
+
+==== Device not found or wrong path
+
+[source,bash,role=execute]
+----
+# Verify device exists
+oc debug node/<node-name> -- chroot /host ls -la /dev/sda
+----
+
+Solution: Update LVMCluster with correct device path
+
+==== Device has existing data/filesystem
+
+[source,bash,role=execute]
+----
+# Check for existing filesystem
+oc debug node/<node-name> -- chroot /host lsblk -f /dev/sda
+----
+
+Solution: Add `forceWipeDevicesAndDestroyAllData: true` to deviceSelector
+
+==== Device is in use
+
+[source,bash,role=execute]
+----
+# Check if mounted
+oc debug node/<node-name> -- chroot /host mount | grep /dev/sda
+----
+
+Solution: Unmount device or use different disk
+
+=== Issue 2: No Volume Group Created
+
+Symptoms:
+
+* LVMCluster exists but `vgs` shows no volume group
+* Device not showing in deviceClassStatuses
+
+Diagnosis:
+
+[source,bash,role=execute]
+----
+# Check if disk was wiped
+oc debug node/<node-name> -- chroot /host pvs
+
+# Check vg-manager logs for errors
+oc logs -n openshift-storage daemonset/vg-manager --tail=100
+
+# Check device visibility
+oc debug node/<node-name> -- chroot /host lsblk -o NAME,SIZE,TYPE,FSTYPE
+----
+
+Solutions:
+
+==== Device not being selected
+
+* Verify deviceSelector paths match actual device
+* Check device is not excluded (see deviceClassStatuses.excluded)
+
+==== Permissions issues
+
+* Ensure vg-manager pod has necessary privileges
+* Check SELinux is not blocking access
+
+==== Device wipe failed
+
+* Set `forceWipeDevicesAndDestroyAllData: true`
+* Manually wipe device and restart operator
+
+=== Issue 3: PVC Stuck in Pending
+
+Symptoms:
+----
+NAME            STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+test-pvc        Pending                                      lvms-vg1       5m
+----
+
+Diagnosis:
+
+[source,bash,role=execute]
+----
+# Check PVC events
+oc describe pvc <pvc-name>
+
+# Check if pod using PVC exists
+oc get pods --all-namespaces -o wide | grep <pvc-name>
+
+# Check available space in VG
+oc debug node/<node-name> -- chroot /host vgs
+----
+
+Common causes:
+
+==== WaitForFirstConsumer - No pod scheduled yet
+
+* **Normal behavior**: PVC stays Pending until a pod using it is scheduled
+* **Solution**: Create a pod that uses the PVC
+
+==== Insufficient space
+
+[source,bash,role=execute]
+----
+# Check VG free space
+oc debug node/<node-name> -- chroot /host vgdisplay vg1 | grep "Free"
+----
+
+Solution: Delete unused PVs or expand volume group
+
+==== Thin pool full
+
+[source,bash,role=execute]
+----
+# Check thin pool usage
+oc debug node/<node-name> -- chroot /host lvs | grep thin-pool
+----
+
+Solution: Clean up volumes or increase thin pool size
+
+==== Node selector mismatch
+
+[source,bash,role=execute]
+----
+# Check pod node selector vs LVMCluster node selector
+oc get pod <pod-name> -o yaml | grep nodeSelector
+oc get lvmcluster lvmcluster -n openshift-storage -o yaml | grep -A 5 nodeSelector
+----
+
+=== Issue 4: Thin Pool Data% or Meta% High
+
+Symptoms:
+----
+LV          VG  Attr       LSize    Data%  Meta%
+thin-pool-1 vg1 twi-a-tz-- 502.04g  92.00  85.00
+----
+
+Diagnosis:
+
+[source,bash,role=execute]
+----
+# Check thin pool details
+oc debug node/<node-name> -- chroot /host lvs -a | grep thin-pool
+
+# List all thin volumes
+oc debug node/<node-name> -- chroot /host lvs -a -o lv_name,lv_size,data_percent,pool_lv | grep thin-pool
+
+# Check which PVs are consuming space
+oc get pv -o custom-columns=NAME:.metadata.name,SIZE:.spec.capacity.storage,STORAGECLASS:.spec.storageClassName | grep lvms
+----
+
+Solutions:
+
+==== Delete unused PVCs
+
+[source,bash,role=execute]
+----
+# Find PVCs not in use
+oc get pvc --all-namespaces
+
+# Delete PVC
+oc delete pvc <pvc-name> -n <namespace>
+----
+
+==== Expand thin pool (if VG has free space)
+
+[source,bash,role=execute]
+----
+# Check VG free space
+oc debug node/<node-name> -- chroot /host vgs
+
+# Extend thin pool (if needed manually)
+# Usually handled automatically by LVM operator
+----
+
+==== Adjust overprovisioning ratio
+
+Edit LVMCluster to reduce `overprovisionRatio`
+
+=== Issue 5: Device Wipe Failed
+
+Symptoms:
+
+* LVMCluster created but device not being used
+* Logs show "cannot wipe device" or "device busy"
+
+Diagnosis:
+
+[source,bash,role=execute]
+----
+# Check current filesystem/partition
+oc debug node/<node-name> -- chroot /host lsblk -f /dev/sda
+
+# Check for LVM signatures
+oc debug node/<node-name> -- chroot /host pvs | grep /dev/sda
+
+# Check if device is open
+oc debug node/<node-name> -- chroot /host lsof | grep /dev/sda
+----
+
+Solution:
+
+[source,bash,role=execute]
+----
+# Ensure forceWipeDevicesAndDestroyAllData is set
+oc edit lvmcluster lvmcluster -n openshift-storage
+
+# Add under deviceSelector:
+forceWipeDevicesAndDestroyAllData: true
+----
+
+=== Issue 6: vg-manager Pod CrashLooping
+
+Symptoms:
+----
+NAME             READY   STATUS             RESTARTS   AGE
+vg-manager-xxx   0/1     CrashLoopBackOff   5          3m
+----
+
+Diagnosis:
+
+[source,bash,role=execute]
+----
+# Check pod logs
+oc logs -n openshift-storage <vg-manager-pod> --previous
+
+# Check pod events
+oc describe pod -n openshift-storage <vg-manager-pod>
+
+# Check node resources
+oc describe node <node-name>
+----
+
+Common causes:
+
+==== Device permissions
+
+* vg-manager may lack permissions to access device
+* Check SELinux denials in node logs
+
+==== Missing device
+
+* Device path in config doesn't exist
+* Device removed or changed name
+
+==== Resource constraints
+
+* Node running out of memory or CPU
+* Check node capacity
+
+=== Issue 7: StorageClass Not Default
+
+Symptoms:
+
+* PVCs without explicit storageClassName fail to bind
+* Warning: "no default deviceClass was specified"
+
+Diagnosis:
+
+[source,bash,role=execute]
+----
+# Check if any StorageClass is default
+oc get storageclass | grep default
+
+# Check lvms StorageClass annotations
+oc get storageclass lvms-vg1 -o yaml | grep is-default-class
+----
+
+Solutions:
+
+==== Set LVM StorageClass as default
+
+[source,bash,role=execute]
+----
+oc patch storageclass lvms-vg1 -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+----
+
+==== Or set default in LVMCluster
+
+[source,bash,role=execute]
+----
+oc edit lvmcluster lvmcluster -n openshift-storage
+
+# Add under deviceClasses:
+- name: vg1
+  default: true
+----
+
+== Comprehensive Diagnostic Script
+
+Save this as a shell script to quickly diagnose LVM storage issues:
+
+[source,bash]
+----
+#!/bin/bash
+
+NAMESPACE="openshift-storage"
+NODE_NAME="<your-node-name>"
+
+echo "=== LVM Storage Diagnostic Report ==="
+echo ""
+
+echo "1. LVMCluster Status:"
+oc get lvmcluster -n $NAMESPACE
+echo ""
+
+echo "2. Pods Status:"
+oc get pods -n $NAMESPACE
+echo ""
+
+echo "3. StorageClass:"
+oc get storageclass | grep lvms
+echo ""
+
+echo "4. PVs:"
+oc get pv | grep topolvm
+echo ""
+
+echo "5. Volume Groups:"
+oc debug node/$NODE_NAME -- chroot /host vgs
+echo ""
+
+echo "6. Logical Volumes:"
+oc debug node/$NODE_NAME -- chroot /host lvs
+echo ""
+
+echo "7. Physical Volumes:"
+oc debug node/$NODE_NAME -- chroot /host pvs
+echo ""
+
+echo "8. Block Devices:"
+oc debug node/$NODE_NAME -- chroot /host lsblk -o NAME,SIZE,TYPE,FSTYPE,MOUNTPOINT
+echo ""
+
+echo "9. Recent vg-manager logs:"
+oc logs -n $NAMESPACE daemonset/vg-manager --tail=20
+echo ""
+
+echo "=== End of Diagnostic Report ==="
+----
+
+== Related Guides
+
+* xref:lvm-operator.adoc[LVM Operator Local Disk Installation Tutorial] - Installation guide with detailed configuration
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "course-starter-template",
+  "name": "ocp-virt-cookbook",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
This PR migrates OpenShift Virtualization content from the [ocp-virt-onboarding-kit](https://github.com/opdev/ocp-virt-onboarding-kit) project, converting it into a structured Antora-based cookbook.

## Changes Summary

- **Added 5 new modules** with tutorials and guides
- **Getting Started**: Prerequisites, virtctl basics, storage setup
- **Storage**: LVM operator installation and troubleshooting  
- **Networking**: UDN, localnet, VLAN, bridges, and OVS troubleshooting
- **VM Configuration**: Cloud-init setup and troubleshooting guides
- **Manifests**: YAML reference library for all components