### PR TITLE
Add VM Configuration Module with Cloud-init Tutorials

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -2,4 +2,5 @@
 ** xref:getting-started:index.adoc[Getting Started]
 ** xref:storage:index.adoc[Storage Configuration]
 ** xref:networking:index.adoc[Networking Configuration]
+** xref:vm-configuration:index.adoc[Virtual Machine Configuration]
 ** xref:manifests:index.adoc[Manifests Reference]

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -39,6 +39,7 @@ This cookbook is organized into focused modules:
 * **xref:getting-started:index.adoc[Getting Started]** - Essential tools and basic configuration
 * **xref:storage:index.adoc[Storage Configuration]** - Setting up storage for virtual machines
 * **xref:networking:index.adoc[Networking Configuration]** - Comprehensive networking guides
+* **xref:vm-configuration:index.adoc[Virtual Machine Configuration]** - Cloud-init and VM customization
 * **xref:manifests:index.adoc[Manifests Reference]** - Ready-to-use YAML examples
 
 Each module contains step-by-step tutorials, practical examples, and troubleshooting guidance.
@@ -64,6 +65,11 @@ Each module contains step-by-step tutorials, practical examples, and troubleshoo
 * xref:networking:cudn-localnet-vlan.adoc[Configuring Localnet Secondary Networks with VLAN using ClusterUserDefinedNetwork]
 * xref:networking:linux-bridges.adoc[Configuring Linux Bridges for VMs]
 * xref:networking:ovs-bridge-verification.adoc[Troubleshooting OVS Bridge Creation for Localnet Networks]
+
+=== Virtual Machine Configuration
+
+* xref:vm-configuration:cloud-init-ip-configuration.adoc[Cloud-init IP Configuration]
+* xref:vm-configuration:cloud-init-troubleshooting.adoc[Cloud-init Troubleshooting]
 
 === Manifests Reference
 

--- a/modules/manifests/pages/index.adoc
+++ b/modules/manifests/pages/index.adoc
@@ -129,6 +129,7 @@ Most manifests in this section are referenced by tutorials in other modules:
 * xref:getting-started:index.adoc[Getting Started] - Basic setup and prerequisites
 * xref:storage:index.adoc[Storage Configuration] - LVM and storage setup
 * xref:networking:index.adoc[Networking Configuration] - Network configuration tutorials
+* xref:vm-configuration:index.adoc[Virtual Machine Configuration] - Cloud-init and VM customization
 
 == Validation
 

--- a/modules/manifests/pages/vms.adoc
+++ b/modules/manifests/pages/vms.adoc
@@ -177,9 +177,10 @@ spec:
 * Static IP on secondary interface via cloud-init
 * 4 vCPUs, 8Gi memory for higher workloads
 
-**Related Tutorial:**
+**Related Tutorials:**
 
 * xref:networking:localnet-vlan.adoc[Localnet Secondary Networks with VLAN using NAD]
+* xref:vm-configuration:cloud-init-ip-configuration.adoc[Cloud-init IP Configuration]
 
 == RHEL VM Examples
 
@@ -691,6 +692,7 @@ Key VM manifest components:
 == See Also
 
 * xref:getting-started:virtctl-basics.adoc[Virtctl Basics]
+* xref:vm-configuration:cloud-init-ip-configuration.adoc[Cloud-init IP Configuration]
 * xref:networking.adoc[Network Configuration]
 * xref:storage.adoc[Storage Configuration]
 * xref:index.adoc[Manifests Reference Overview]

--- a/modules/vm-configuration/nav.adoc
+++ b/modules/vm-configuration/nav.adoc
@@ -1,0 +1,4 @@
+* xref:index.adoc[Virtual Machine Configuration]
+** xref:cloud-init-ip-configuration.adoc[Cloud-init IP Configuration]
+** xref:cloud-init-troubleshooting.adoc[Cloud-init Troubleshooting]
+

--- a/modules/vm-configuration/pages/cloud-init-ip-configuration.adoc
+++ b/modules/vm-configuration/pages/cloud-init-ip-configuration.adoc
@@ -1,0 +1,645 @@
+= Configuring IP Addresses with Cloud-init
+:navtitle: Cloud-init IP Configuration
+
+== Overview
+
+This tutorial demonstrates how to configure static and dynamic IP addresses for virtual machines in OpenShift Virtualization using cloud-init. Cloud-init is a standard method for initializing cloud instances with custom configurations, including network settings.
+
+== What is Cloud-init?
+
+Cloud-init is an industry-standard initialization tool that runs during VM boot to:
+
+* Configure network interfaces
+* Set hostnames
+* Create users and SSH keys
+* Run custom scripts
+* Install packages
+
+For networking, cloud-init supports both userData (generic configuration) and networkData (dedicated network configuration) sections.
+
+== Prerequisites
+
+* OpenShift 4.17+ with OpenShift Virtualization operator installed
+* CLI tools: `oc`, `virtctl`, `kubectl`
+* At least one configured network (primary pod network)
+* For VLAN scenarios: secondary network configured (see localnet VLAN tutorial)
+* Basic understanding of networking (IP, subnet, gateway, DNS)
+
+== Cloud-init Network Configuration Basics
+
+=== userData vs networkData
+
+* **userData**: General cloud-init configuration (users, packages, scripts)
+* **networkData**: Dedicated network interface configuration (preferred for networking)
+
+=== Configuration Format
+
+Cloud-init network configuration supports version 2 format, which uses netplan-compatible schema:
+
+[source,yaml]
+----
+networkData: |
+  version: 2
+  ethernets:
+    enp1s0:
+      dhcp4: true
+----
+
+=== Precedence Order
+
+1. networkData configuration (highest priority)
+2. Datasource network configuration
+3. Fallback to DHCP (default)
+
+== Scenario 1: Single Interface with DHCP (Default)
+
+The simplest configuration - VM uses DHCP on the primary pod network.
+
+Create namespace:
+
+[source,bash,role=execute]
+----
+oc create namespace cloud-init-demo
+----
+
+VM manifest without explicit network configuration:
+
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora-dhcp-vm
+  namespace: cloud-init-demo
+spec:
+  dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: fedora-dhcp-vm-disk
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: fedora
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources:
+            requests:
+              storage: 30Gi
+  runStrategy: RerunOnFailure
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: fedora-dhcp-vm
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - masquerade: {}
+              name: default
+          rng: {}
+        machine:
+          type: pc-q35-rhel9.4.0
+        memory:
+          guest: 4Gi
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - dataVolume:
+            name: fedora-dhcp-vm-disk
+          name: rootdisk
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: fedora123
+              chpasswd: { expire: False }
+              ssh_pwauth: True
+          name: cloudinitdisk
+----
+
+Deploy and verify:
+
+[source,bash,role=execute]
+----
+oc apply -f fedora-dhcp-vm.yaml
+oc get vmi -n cloud-init-demo
+----
+
+Access the VM and check the IP:
+
+[source,bash,role=execute]
+----
+virtctl console fedora-dhcp-vm -n cloud-init-demo
+----
+
+Inside the VM:
+
+[source,bash]
+----
+ip addr show enp1s0
+----
+
+The interface will have an IP from the pod network (typically 10.128.x.x range).
+
+When to use: Development environments, simple deployments, when DHCP is sufficient.
+
+== Scenario 2: Single Interface with Static IP
+
+Configure a static IP on the primary interface. Note: This is not common for pod networks but useful for understanding the syntax.
+
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora-static-vm
+  namespace: cloud-init-demo
+spec:
+  dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: fedora-static-vm-disk
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: fedora
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources:
+            requests:
+              storage: 30Gi
+  runStrategy: RerunOnFailure
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: fedora-static-vm
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - masquerade: {}
+              name: default
+          rng: {}
+        machine:
+          type: pc-q35-rhel9.4.0
+        memory:
+          guest: 4Gi
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - dataVolume:
+            name: fedora-static-vm-disk
+          name: rootdisk
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: fedora123
+              chpasswd: { expire: False }
+              ssh_pwauth: True
+            networkData: |-
+              version: 2
+              ethernets:
+                enp1s0:
+                  dhcp4: false
+                  dhcp6: false
+                  addresses:
+                    - 10.128.1.100/23
+                  routes:
+                    - to: default
+                      via: 10.128.1.1
+                  nameservers:
+                    addresses:
+                      - 8.8.8.8
+                      - 8.8.4.4
+          name: cloudinitdisk
+----
+
+Key points:
+
+* `dhcp4: false` and `dhcp6: false` disable DHCP
+* `addresses` sets the static IP with CIDR notation
+* `routes` with `to: default` sets the default gateway
+* `nameservers` configures DNS servers
+
+== Scenario 3: Multiple Interfaces - Primary DHCP + Secondary Static
+
+This is the most common real-world scenario. Primary interface uses DHCP, secondary interface (on VLAN or bridge) uses static IP.
+
+Prerequisites: Ensure you have a secondary network configured (e.g., localnet VLAN 100).
+
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora-multi-vm
+  namespace: cloud-init-demo
+spec:
+  dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: fedora-multi-vm-disk
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: fedora
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources:
+            requests:
+              storage: 30Gi
+  runStrategy: RerunOnFailure
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: fedora-multi-vm
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - masquerade: {}
+              name: default
+            - bridge: {}
+              name: vlan-network
+          rng: {}
+        machine:
+          type: pc-q35-rhel9.4.0
+        memory:
+          guest: 4Gi
+      networks:
+        - name: default
+          pod: {}
+        - name: vlan-network
+          multus:
+            networkName: localnet-vlan-100
+      volumes:
+        - dataVolume:
+            name: fedora-multi-vm-disk
+          name: rootdisk
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: fedora123
+              chpasswd: { expire: False }
+              ssh_pwauth: True
+            networkData: |-
+              version: 2
+              ethernets:
+                enp1s0:
+                  dhcp4: true
+                enp2s0:
+                  dhcp4: false
+                  dhcp6: false
+                  addresses:
+                    - 192.168.100.50/24
+                  nameservers:
+                    addresses:
+                      - 192.168.100.1
+          name: cloudinitdisk
+----
+
+Important notes:
+
+* `enp1s0` (first interface) uses DHCP and gets the default route automatically
+* `enp2s0` (second interface) has static IP without default route
+* DNS servers on secondary interface are optional
+* Do not set default route on secondary interface
+
+Verification:
+
+[source,bash,role=execute]
+----
+virtctl console fedora-multi-vm -n cloud-init-demo
+----
+
+Inside the VM:
+
+[source,bash]
+----
+# Check both interfaces
+ip addr show
+
+# Verify routing table (only one default route via enp1s0)
+ip route show
+
+# Test secondary network
+ping 192.168.100.1
+----
+
+== Scenario 4: VLAN Interface with Static IP
+
+Similar to Scenario 3 but specifically for VLAN networks.
+
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora-vlan-vm
+  namespace: cloud-init-demo
+spec:
+  dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: fedora-vlan-vm-disk
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: fedora
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources:
+            requests:
+              storage: 30Gi
+  runStrategy: RerunOnFailure
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: fedora-vlan-vm
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - masquerade: {}
+              name: default
+            - bridge: {}
+              name: vlan-100
+          rng: {}
+        machine:
+          type: pc-q35-rhel9.4.0
+        memory:
+          guest: 4Gi
+      networks:
+        - name: default
+          pod: {}
+        - name: vlan-100
+          multus:
+            networkName: localnet-vlan-100
+      volumes:
+        - dataVolume:
+            name: fedora-vlan-vm-disk
+          name: rootdisk
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: fedora
+              password: fedora123
+              chpasswd: { expire: False }
+              ssh_pwauth: True
+              write_files:
+                - path: /var/www/html/index.html
+                  content: |
+                    <html>
+                    <body>
+                      <h1>VM on VLAN 100</h1>
+                      <p>IP: 192.168.100.50</p>
+                    </body>
+                    </html>
+                  permissions: '0644'
+              runcmd:
+                - dnf install -y python3
+                - cd /var/www/html && python3 -m http.server 80 &
+            networkData: |-
+              version: 2
+              ethernets:
+                enp1s0:
+                  dhcp4: true
+                enp2s0:
+                  dhcp4: false
+                  dhcp6: false
+                  addresses:
+                    - 192.168.100.50/24
+          name: cloudinitdisk
+----
+
+This example also demonstrates:
+
+* Using `write_files` to create content
+* Using `runcmd` to start a simple web server
+* Static IP on VLAN interface
+
+== Verification Commands
+
+After deploying any scenario, use these commands to verify:
+
+=== Check VM Status
+
+[source,bash,role=execute]
+----
+# Check VirtualMachine
+oc get vm -n cloud-init-demo
+
+# Check VirtualMachineInstance
+oc get vmi -n cloud-init-demo
+
+# Get detailed VMI info
+oc describe vmi <vm-name> -n cloud-init-demo
+----
+
+=== Access VM Console
+
+[source,bash,role=execute]
+----
+virtctl console <vm-name> -n cloud-init-demo
+----
+
+Exit console with `Ctrl+]`.
+
+=== Inside the VM
+
+[source,bash]
+----
+# Show all interfaces
+ip addr show
+
+# Show routing table
+ip route show
+
+# Show DNS configuration
+cat /etc/resolv.conf
+
+# Test connectivity
+ping -c 3 8.8.8.8
+ping -c 3 google.com
+
+# Check cloud-init status
+cloud-init status
+
+# View cloud-init logs
+sudo cat /var/log/cloud-init.log
+sudo cat /var/log/cloud-init-output.log
+
+# Check applied network configuration
+nmcli device show
+nmcli connection show
+----
+
+== Common Issues and Solutions
+
+=== Issue: Interface names don't match
+
+**Problem**: Used `eth0` instead of `enp1s0` in networkData.
+
+**Solution**: Use the interface names as they appear in your guest operating system. Modern Linux distributions (RHEL 8+, Fedora, Ubuntu 16.04+) use predictable naming: `enp1s0`, `enp2s0`, etc.
+
+=== Issue: VM has no connectivity on secondary interface
+
+**Problem**: Forgot to disable DHCP on static interface.
+
+**Solution**: Always set `dhcp4: false` and `dhcp6: false` when using static IPs.
+
+=== Issue: Multiple default routes
+
+**Problem**: Set default route on both interfaces.
+
+**Solution**: Only set default route on primary interface (usually the first interface). Secondary interfaces should not have default routes.
+
+=== Issue: Cloud-init configuration not applied
+
+**Problem**: Syntax error in YAML or cloud-init configuration.
+
+**Solution**:
+
+* Check cloud-init logs: `/var/log/cloud-init.log`
+* Verify YAML indentation
+* Use `cloud-init status` to check for errors
+
+=== Issue: DNS not resolving on secondary network
+
+**Problem**: Nameservers not configured or wrong nameservers.
+
+**Solution**: Add appropriate nameservers in the networkData for the interface. If secondary interface is for isolated network, may not need external DNS.
+
+For detailed troubleshooting, see the xref:cloud-init-troubleshooting.adoc[Cloud-init Troubleshooting Guide].
+
+== Best Practices
+
+=== Network Configuration
+
+* Use networkData for all network interface configurations
+* Always disable DHCP explicitly when using static IPs
+* Only configure default route on primary interface
+* Verify interface names in your guest OS before configuring
+* Test configurations in dev environment first
+
+=== Cloud-init Usage
+
+* Keep configurations simple and readable
+* Use write_files for complex file content
+* Avoid complex shell scripts in runcmd
+* Validate YAML syntax before deploying
+* Check cloud-init logs when troubleshooting
+
+=== IP Address Planning
+
+* Document IP assignments for all VMs
+* Use consistent IP ranges for different purposes
+* Avoid IP conflicts by maintaining IP inventory
+* Consider using DHCP reservations for dynamic scenarios
+
+=== Security
+
+* Don't hardcode passwords in production
+* Use SSH keys instead of passwords
+* Restrict access to appropriate networks
+* Configure firewall rules via cloud-init if needed
+
+== When to Use Each Approach
+
+=== Use DHCP when:
+
+* Quick development and testing
+* IP address doesn't need to be predictable
+* DHCP server is available and reliable
+* VM is ephemeral
+
+=== Use Static IP when:
+
+* VM hosts a service that needs consistent addressing
+* Integration with external systems requires fixed IP
+* DHCP is not available on the network
+* Production environments requiring predictability
+
+=== Use Multiple Interfaces when:
+
+* Separating management and data traffic
+* Connecting to multiple networks (pod network + VLAN)
+* Implementing network segmentation
+* Compliance requirements for network isolation
+
+== Cleanup
+
+To remove all resources created in this tutorial:
+
+[source,bash,role=execute]
+----
+# Delete VMs
+oc delete vm fedora-dhcp-vm fedora-static-vm fedora-multi-vm fedora-vlan-vm -n cloud-init-demo
+
+# Delete namespace
+oc delete namespace cloud-init-demo
+----
+
+== Summary
+
+In this tutorial, you learned:
+
+* How cloud-init network configuration works in OpenShift Virtualization
+* KubeVirt's predictable network interface naming
+* How to configure DHCP and static IP addresses
+* How to configure multiple network interfaces
+* How to verify network configuration
+* Best practices for cloud-init networking
+* Common issues and solutions
+
+== References
+
+* link:https://cloudinit.readthedocs.io/[Cloud-init Documentation,window=_blank]
+* link:https://cloudinit.readthedocs.io/en/latest/reference/network-config.html[Cloud-init Network Configuration,window=_blank]
+* link:https://docs.openshift.com/container-platform/latest/virt/about_virt/about-virt.html[OpenShift Virtualization Documentation,window=_blank]
+* link:https://kubevirt.io/user-guide/[KubeVirt Documentation,window=_blank]
+

--- a/modules/vm-configuration/pages/cloud-init-troubleshooting.adoc
+++ b/modules/vm-configuration/pages/cloud-init-troubleshooting.adoc
@@ -1,0 +1,829 @@
+= Cloud-init IP Configuration Troubleshooting Guide
+:navtitle: Cloud-init Troubleshooting
+
+This guide provides comprehensive troubleshooting steps, verification commands, and solutions for issues related to configuring IP addresses with cloud-init in OpenShift Virtualization.
+
+== Table of Contents
+
+* <<quick-health-checks,Quick Health Checks>>
+* <<debugging-cloud-init,Debugging Cloud-init>>
+* <<common-issues-by-scenario,Common Issues by Scenario>>
+* <<diagnostic-commands,Diagnostic Commands>>
+
+== Quick Health Checks
+
+=== Check VM Status
+
+[source,bash,role=execute]
+----
+oc get vm <vm-name> -n <namespace>
+oc get vmi <vm-name> -n <namespace>
+----
+
+=== Check VM Has IP Address
+
+[source,bash,role=execute]
+----
+oc get vmi <vm-name> -n <namespace> -o jsonpath='{.status.interfaces[*].ipAddress}'
+----
+
+=== Check Guest Agent is Running
+
+[source,bash,role=execute]
+----
+oc get vmi <vm-name> -n <namespace> -o jsonpath='{.status.guestOSInfo}'
+----
+
+If empty, guest agent is not running (see <<issue-1-guest-agent-not-running,Guest Agent Issues>>).
+
+== Debugging Cloud-init
+
+=== Access VM Console
+
+[source,bash,role=execute]
+----
+virtctl console <vm-name> -n <namespace>
+----
+
+=== Check Cloud-init Status
+
+Inside VM:
+
+[source,bash]
+----
+# Check cloud-init completion status
+cloud-init status
+
+# Expected output for success:
+# status: done
+
+# Check detailed status
+cloud-init status --long
+----
+
+=== Check Cloud-init Logs
+
+[source,bash]
+----
+# Main cloud-init log
+cat /var/log/cloud-init.log
+
+# Output log (shows command execution)
+cat /var/log/cloud-init-output.log
+
+# Check for errors
+grep -i error /var/log/cloud-init.log
+grep -i failed /var/log/cloud-init.log
+----
+
+=== View Applied Cloud-init Configuration
+
+[source,bash]
+----
+# View userdata
+sudo cat /var/lib/cloud/instance/user-data.txt
+
+# View network config (if using networkData)
+sudo cat /var/lib/cloud/instance/network-config.txt
+
+# View cloud-init data
+sudo cat /var/lib/cloud/instance/cloud-config.txt
+----
+
+=== Check Network Configuration
+
+[source,bash]
+----
+# View network interfaces
+ip addr show
+
+# View routing table
+ip route show
+
+# Check DNS configuration
+cat /etc/resolv.conf
+
+# For NetworkManager systems (Fedora, RHEL)
+nmcli device status
+nmcli connection show
+----
+
+=== Test Connectivity
+
+[source,bash]
+----
+# Test network connectivity
+ping -c 3 8.8.8.8
+
+# Test DNS resolution
+nslookup google.com
+
+# Test from pod network
+curl http://<vm-ip>
+----
+
+== Common Issues by Scenario
+
+=== Scenario 1: DHCP Configuration
+
+==== Issue: VM Not Getting IP via DHCP
+
+**Symptoms**:
+
+[source,bash]
+----
+$ oc get vmi fedora-dhcp-vm -n vms -o jsonpath='{.status.interfaces[0].ipAddress}'
+# Returns empty or shows no IP
+----
+
+**Diagnosis**:
+
+[source,bash]
+----
+# Access VM console
+virtctl console fedora-dhcp-vm -n vms
+
+# Check interface status
+ip addr show enp1s0
+
+# Check DHCP client
+journalctl -u NetworkManager | grep -i dhcp
+----
+
+**Common Causes**:
+
+* DHCP client not running
+* Network interface down
+* Cloud-init DHCP configuration error
+
+**Solutions**:
+
+1. Verify cloud-init DHCP config in VM definition:
++
+[source,yaml]
+----
+cloudInitNoCloud:
+  networkData: |
+    version: 2
+    ethernets:
+      enp1s0:
+        dhcp4: true
+----
+
+2. Manually restart network interface:
++
+[source,bash]
+----
+sudo nmcli connection down "Wired connection 1"
+sudo nmcli connection up "Wired connection 1"
+----
+
+3. Check NetworkManager logs:
++
+[source,bash]
+----
+sudo journalctl -u NetworkManager --since "5 minutes ago"
+----
+
+==== Issue: Wrong Interface Name in Cloud-init
+
+**Symptoms**:
+Network configuration not applied, logs show "device eth0 not found".
+
+**Diagnosis**:
+
+[source,bash]
+----
+# Inside VM - check actual interface names
+ip link show
+----
+
+**Common Causes**:
+
+* Using generic names (`eth0`, `eth1`) instead of the interface names used by your guest OS
+
+**Solutions**:
+
+1. Check the actual interface names in your guest OS. Modern Linux distributions (RHEL 8+, Fedora, Ubuntu 16.04+) use predictable naming:
+   * First interface: `enp1s0`
+   * Second interface: `enp2s0`
+   * Third interface: `enp3s0`
+
+2. Update cloud-init networkData to use correct names:
++
+[source,yaml]
+----
+networkData: |
+  version: 2
+  ethernets:
+    enp1s0:  # Not eth0
+      dhcp4: true
+----
+
+=== Scenario 2: Static IP Configuration
+
+==== Issue: Static IP Not Applied
+
+**Symptoms**:
+VM gets DHCP IP instead of configured static IP.
+
+**Diagnosis**:
+
+[source,bash]
+----
+# Inside VM
+ip addr show enp1s0
+
+# Check cloud-init logs for errors
+grep -i "network" /var/log/cloud-init.log
+----
+
+**Common Causes**:
+
+* Wrong interface name in networkData
+* DHCP still enabled
+* Syntax errors in networkData YAML
+* cloud-init not processing networkData
+
+**Solutions**:
+
+1. Verify networkData syntax (indentation, YAML format):
++
+[source,yaml]
+----
+networkData: |
+  version: 2
+  ethernets:
+    enp1s0:
+      dhcp4: false  # Disable DHCP
+      addresses:
+        - 192.168.1.100/24
+      routes:
+        - to: default
+          via: 192.168.1.1
+      nameservers:
+        addresses:
+          - 8.8.8.8
+          - 8.8.4.4
+----
+
+2. Check for cloud-init errors:
++
+[source,bash]
+----
+cloud-init status --long
+cat /var/log/cloud-init.log | grep -A 5 -B 5 "network"
+----
+
+3. Manually apply network configuration:
++
+[source,bash]
+----
+sudo nmcli connection modify "Wired connection 1" \
+  ipv4.method manual \
+  ipv4.addresses 192.168.1.100/24 \
+  ipv4.gateway 192.168.1.1 \
+  ipv4.dns "8.8.8.8 8.8.4.4"
+
+sudo nmcli connection up "Wired connection 1"
+----
+
+==== Issue: Static IP Applied But No Connectivity
+
+**Symptoms**:
+
+[source,bash]
+----
+# Inside VM
+ip addr show enp1s0
+# Shows correct IP
+
+ping 192.168.1.1
+# Network unreachable
+----
+
+**Diagnosis**:
+
+[source,bash]
+----
+# Check routing table
+ip route show
+
+# Check if gateway is reachable
+ping -c 1 192.168.1.1
+----
+
+**Common Causes**:
+
+* Missing or wrong gateway
+* Wrong subnet mask
+* Physical network not configured for static IPs
+* Switch port in wrong VLAN
+
+**Solutions**:
+
+1. Verify gateway in cloud-init configuration
+2. Check subnet mask matches network configuration
+3. Verify physical network allows static IPs on this subnet
+4. If using VLAN, ensure NAD and bridge mapping are correct
+
+=== Scenario 3: Multiple Network Interfaces
+
+==== Issue: Secondary Interface Not Configured
+
+**Symptoms**:
+Only primary interface has IP, secondary interface down or unconfigured.
+
+**Diagnosis**:
+
+[source,bash]
+----
+# Inside VM
+ip addr show
+
+# Check NetworkManager connections
+nmcli connection show
+----
+
+**Common Causes**:
+
+* Secondary interface not defined in networkData
+* Wrong interface name for secondary interface
+* Secondary network attachment not working
+
+**Solutions**:
+
+1. Verify VM has multiple network attachments:
++
+[source,yaml]
+----
+spec:
+  template:
+    spec:
+      networks:
+        - name: default
+          pod: {}
+        - name: secondary-net
+          multus:
+            networkName: my-nad
+----
+
+2. Verify both interfaces in networkData:
++
+[source,yaml]
+----
+networkData: |
+  version: 2
+  ethernets:
+    enp1s0:
+      dhcp4: true
+    enp2s0:  # Secondary interface
+      dhcp4: false
+      addresses:
+        - 192.168.100.10/24
+----
+
+3. Check NAD exists and is configured:
++
+[source,bash,role=execute]
+----
+oc get network-attachment-definition -n <namespace>
+oc describe network-attachment-definition <nad-name> -n <namespace>
+----
+
+==== Issue: Default Route Conflict
+
+**Symptoms**:
+Both interfaces have default routes, causing routing issues.
+
+**Diagnosis**:
+
+[source,bash]
+----
+# Inside VM
+ip route show
+
+# Will show multiple default routes
+# default via 10.128.0.1 dev enp1s0
+# default via 192.168.100.1 dev enp2s0
+----
+
+**Common Causes**:
+
+* Both interfaces configured with default gateway
+* DHCP adding default route on primary interface
+* Static config adding default route on secondary interface
+
+**Solutions**:
+
+1. Remove default route from secondary interface in networkData:
++
+[source,yaml]
+----
+enp2s0:
+  dhcp4: false
+  addresses:
+    - 192.168.100.10/24
+  # No 'routes' section - no default gateway
+----
+
+2. If both need routes, use metrics to prioritize:
++
+[source,yaml]
+----
+enp1s0:
+  dhcp4: true
+  dhcp4-overrides:
+    route-metric: 100  # Lower is preferred
+
+enp2s0:
+  dhcp4: false
+  addresses:
+    - 192.168.100.10/24
+  routes:
+    - to: default
+      via: 192.168.100.1
+      metric: 200  # Higher = less preferred
+----
+
+=== Scenario 4: VLAN Interface Configuration
+
+==== Issue: VLAN Interface Not Created
+
+**Symptoms**:
+VLAN interface (e.g., `enp2s0.100`) doesn't exist.
+
+**Diagnosis**:
+
+[source,bash]
+----
+# Inside VM
+ip link show
+
+# Check cloud-init logs
+grep -i vlan /var/log/cloud-init.log
+----
+
+**Common Causes**:
+
+* VLAN configuration syntax error in networkData
+* Parent interface not up
+* VLAN module not loaded
+
+**Solutions**:
+
+1. Verify VLAN configuration in networkData:
++
+[source,yaml]
+----
+networkData: |
+  version: 2
+  ethernets:
+    enp2s0: {}  # Parent interface must be defined
+  vlans:
+    vlan100:
+      id: 100
+      link: enp2s0
+      addresses:
+        - 192.168.100.10/24
+----
+
+2. Manually create VLAN interface:
++
+[source,bash]
+----
+sudo nmcli connection add type vlan \
+  con-name vlan100 \
+  ifname enp2s0.100 \
+  dev enp2s0 \
+  id 100 \
+  ip4 192.168.100.10/24
+----
+
+==== Issue: VLAN Interface Has No Connectivity
+
+**Symptoms**:
+VLAN interface exists but cannot reach network.
+
+**Diagnosis**:
+
+[source,bash]
+----
+# Check VLAN interface status
+ip addr show enp2s0.100
+
+# Check if traffic is tagged
+tcpdump -i enp2s0 -n vlan 100
+----
+
+**Common Causes**:
+
+* Physical switch port not in trunk mode
+* VLAN not allowed on switch trunk
+* Wrong VLAN ID in configuration
+* NAD not configured for VLAN
+
+**Solutions**:
+
+1. Verify switch port is in trunk mode and allows VLAN 100
+2. Verify NAD VLAN configuration:
++
+[source,bash,role=execute]
+----
+oc get network-attachment-definition <nad-name> -n <namespace> -o yaml
+----
++
+Look for: `"vlan": 100`
+
+3. Verify OVN bridge mapping for localnet:
++
+[source,bash,role=execute]
+----
+oc get nncp -A
+----
+
+=== Scenario 5: IPv6 Configuration
+
+==== Issue: IPv6 Address Not Applied
+
+**Symptoms**:
+Only IPv4 configured, no IPv6 address.
+
+**Diagnosis**:
+
+[source,bash]
+----
+# Inside VM
+ip -6 addr show
+----
+
+**Common Causes**:
+
+* IPv6 not enabled in cloud-init
+* IPv6 disabled in OS
+
+**Solutions**:
+
+1. Enable IPv6 in networkData:
++
+[source,yaml]
+----
+networkData: |
+  version: 2
+  ethernets:
+    enp1s0:
+      dhcp4: true
+      dhcp6: true
+      # Or static IPv6:
+      addresses:
+        - 2001:db8::10/64
+----
+
+2. Check IPv6 is not disabled:
++
+[source,bash]
+----
+cat /proc/sys/net/ipv6/conf/all/disable_ipv6
+# Should be 0 (enabled)
+----
+
+=== Scenario 6: DNS Configuration
+
+==== Issue: DNS Not Working
+
+**Symptoms**:
+
+[source,bash]
+----
+# Inside VM
+ping 8.8.8.8
+# Works
+
+ping google.com
+# Unknown host
+----
+
+**Diagnosis**:
+
+[source,bash]
+----
+cat /etc/resolv.conf
+
+# Check DNS resolution
+nslookup google.com
+----
+
+**Common Causes**:
+
+* Nameservers not configured in cloud-init
+* DHCP not providing DNS servers
+* `/etc/resolv.conf` empty or wrong
+
+**Solutions**:
+
+1. Add nameservers to networkData:
++
+[source,yaml]
+----
+networkData: |
+  version: 2
+  ethernets:
+    enp1s0:
+      dhcp4: false
+      addresses:
+        - 192.168.1.100/24
+      nameservers:
+        addresses:
+          - 8.8.8.8
+          - 8.8.4.4
+        search:
+          - example.com
+----
+
+2. Manually configure DNS:
++
+[source,bash]
+----
+echo "nameserver 8.8.8.8" | sudo tee /etc/resolv.conf
+----
+
+== Diagnostic Commands
+
+=== Full Network Status Check
+
+[source,bash]
+----
+# Inside VM - comprehensive network check
+echo "=== Interfaces ==="
+ip addr show
+
+echo "=== Routes ==="
+ip route show
+
+echo "=== DNS ==="
+cat /etc/resolv.conf
+
+echo "=== Cloud-init Status ==="
+cloud-init status --long
+
+echo "=== Cloud-init Network Config ==="
+sudo cat /var/lib/cloud/instance/network-config.txt
+
+echo "=== NetworkManager Connections ==="
+nmcli connection show
+
+echo "=== Connectivity Tests ==="
+ping -c 2 8.8.8.8 && echo "IP connectivity: OK" || echo "IP connectivity: FAILED"
+nslookup google.com && echo "DNS: OK" || echo "DNS: FAILED"
+----
+
+=== From OpenShift Cluster
+
+[source,bash,role=execute]
+----
+# Check VM status
+oc get vm,vmi <vm-name> -n <namespace>
+
+# Check VM IP addresses
+oc get vmi <vm-name> -n <namespace> -o jsonpath='{.status.interfaces}' | jq
+
+# Check network attachments
+oc get vm <vm-name> -n <namespace> -o jsonpath='{.spec.template.spec.networks}' | jq
+
+# Check NADs
+oc get network-attachment-definition -n <namespace>
+
+# Check VM events
+oc get events -n <namespace> --field-selector involvedObject.name=<vm-name> --sort-by='.lastTimestamp'
+
+# Check VM definition cloud-init sections
+oc get vm <vm-name> -n <namespace> -o yaml | grep -A 50 cloudInitNoCloud
+----
+
+=== Cloud-init Rerun (For Testing)
+
+[source,bash]
+----
+# Inside VM - clean and rerun cloud-init (DESTRUCTIVE)
+sudo cloud-init clean --logs
+sudo cloud-init init
+sudo cloud-init modules --mode config
+sudo cloud-init modules --mode final
+
+# Check status
+cloud-init status --long
+----
+
+== Interface Naming Reference
+
+Modern Linux distributions in VMs use predictable interface names based on PCI slot positions:
+
+[cols="1,1,2"]
+|===
+|Network Attachment Order |Interface Name |Typical Usage
+
+|1st (default pod network)
+|`enp1s0`
+|Primary network (DHCP)
+
+|2nd (Multus/NAD)
+|`enp2s0`
+|Secondary network
+
+|3rd (Multus/NAD)
+|`enp3s0`
+|Third network
+
+|4th (Multus/NAD)
+|`enp4s0`
+|Fourth network
+|===
+
+**Use the interface names as they appear in your guest OS. Modern Linux distributions (RHEL 8+, Fedora, Ubuntu 16.04+) use the enpXsY format shown above. Older distributions may still use eth0, eth1, etc.**
+
+== Cloud-init Version Differences
+
+=== cloud-init v1 vs v2 Network Config
+
+**Version 1** (older, legacy):
+
+[source,yaml]
+----
+networkData: |
+  version: 1
+  config:
+    - type: physical
+      name: eth0
+      subnets:
+        - type: dhcp
+----
+
+**Version 2** (modern, recommended):
+
+[source,yaml]
+----
+networkData: |
+  version: 2
+  ethernets:
+    enp1s0:
+      dhcp4: true
+----
+
+**Recommendation**: Always use version 2 for new configurations.
+
+== Additional Resources
+
+* link:https://cloudinit.readthedocs.io/en/latest/reference/network-config.html[Cloud-init Documentation - Network Configuration,window=_blank]
+* link:https://netplan.io/examples/[Netplan Configuration Examples,window=_blank]
+* link:https://docs.openshift.com/container-platform/latest/virt/vm_networking/virt-about-vm-networking.html[OpenShift Virtualization Networking,window=_blank]
+* link:https://kubevirt.io/user-guide/virtual_machines/interfaces_and_networks/[KubeVirt Network Configuration,window=_blank]
+* xref:networking:ovs-bridge-verification.adoc[OVS Bridge Verification]
+
+== Example Test: ocplab01 Cluster
+
+From testing on the SNO cluster (ocplab01):
+
+[source,bash]
+----
+$ oc get vmi fedora-dhcp-vm -n cloud-init-test -o jsonpath='{.status.interfaces}' | jq
+[
+  {
+    "infoSource": "domain, guest-agent, multus-status",
+    "interfaceName": "eth0",
+    "ipAddress": "10.128.0.165",
+    "ipAddresses": [
+      "10.128.0.165",
+      "fd02::5e"
+    ],
+    "mac": "02:92:c2:00:00:05",
+    "name": "default",
+    "queueCount": 1
+  }
+]
+----
+
+**Note**: The `interfaceName` field shows `eth0` in VMI status (internal KubeVirt naming), but inside the Fedora VM the interface is `enp1s0`. Always use the interface names as they appear in your guest OS for cloud-init configuration.
+
+Inside VM verification:
+
+[source,bash]
+----
+[fedora@fedora ~]$ ip addr show enp1s0
+2: enp1s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1400 qdisc fq_codel state UP group default qlen 1000
+    link/ether 02:92:c2:00:00:05 brd ff:ff:ff:ff:ff:ff
+    inet 10.128.0.165/23 brd 10.128.1.255 scope global dynamic noprefixroute enp1s0
+       valid_lft 86295sec preferred_lft 86295sec
+    inet6 fd02::5e/64 scope global dynamic noprefixroute
+       valid_lft 86296sec preferred_lft 14296sec
+----
+
+Cloud-init status:
+
+[source,bash]
+----
+[fedora@fedora ~]$ cloud-init status
+status: done
+----
+
+This confirms DHCP scenario works correctly with proper interface naming.
+

--- a/modules/vm-configuration/pages/index.adoc
+++ b/modules/vm-configuration/pages/index.adoc
@@ -1,0 +1,99 @@
+= Virtual Machine Configuration
+:navtitle: VM Configuration
+
+== Overview
+
+This section covers virtual machine configuration in OpenShift Virtualization, focusing on cloud-init and network initialization patterns. Cloud-init is the standard tool for VM initialization and configuration.
+
+== What You'll Learn
+
+Learn how to configure and customize virtual machines in OpenShift Virtualization:
+
+* Cloud-init basics and network configuration
+* Static and dynamic IP address assignment
+* Multiple network interface configuration
+* Best practices for VM initialization
+
+== Prerequisites
+
+Before working with VM configuration, ensure you have:
+
+* OpenShift 4.17+ with OpenShift Virtualization operator installed
+* Basic understanding of virtual machines and networking
+* Familiarity with YAML syntax
+* CLI tools installed: `oc`, `virtctl`, `kubectl`
+
+== Topics
+
+xref:cloud-init-ip-configuration.adoc[Cloud-init IP Configuration]::
+Configure static and dynamic IP addresses using cloud-init for virtual machines with single and multiple network interfaces.
+
+xref:cloud-init-troubleshooting.adoc[Cloud-init Troubleshooting]::
+Comprehensive troubleshooting guide for cloud-init IP configuration issues, including diagnostic commands and common problem solutions.
+
+== Key Concepts
+
+=== Cloud-init
+
+Cloud-init is an industry-standard initialization tool that configures cloud instances during first boot. It supports:
+
+* Network configuration (networkData)
+* User and SSH key setup (userData)
+* Package installation
+* Custom scripts and commands
+* File creation and modification
+
+=== Network Interface Naming
+
+KubeVirt uses predictable network interface naming based on PCI slot positions:
+
+* Primary interface: `enp1s0`
+* Secondary interface: `enp2s0`
+* Additional interfaces: `enp3s0`, `enp4s0`, etc.
+
+This differs from traditional `eth0`, `eth1` naming found in older Linux distributions.
+
+=== VM Network Types
+
+OpenShift Virtualization supports multiple network attachment methods:
+
+* **Masquerade**: Default pod network with NAT
+* **Bridge**: Direct bridge to secondary networks (VLANs, localnet)
+* **SR-IOV**: High-performance direct hardware access
+* **Macvtap**: Direct network attachment with MAC filtering
+
+== Best Practices
+
+=== Configuration Management
+
+* Use networkData for network-specific configuration
+* Keep userData for general system initialization
+* Test configurations in development before production
+* Validate YAML syntax before deployment
+
+=== Network Design
+
+* Use DHCP for ephemeral/development workloads
+* Use static IPs for production services
+* Only set default route on primary interface
+* Document IP assignments and network topology
+
+=== Security
+
+* Avoid hardcoding passwords in production
+* Use SSH keys for authentication
+* Implement network segmentation
+* Apply least privilege principles
+
+== Related Topics
+
+* xref:getting-started:index.adoc[Getting Started] - Initial setup and prerequisites
+* xref:storage:index.adoc[Storage Configuration] - Persistent storage for VMs
+* xref:networking:index.adoc[Networking Configuration] - Network infrastructure setup
+
+== Additional Resources
+
+* link:https://docs.openshift.com/container-platform/latest/virt/about_virt/about-virt.html[OpenShift Virtualization Documentation,window=_blank]
+* link:https://cloudinit.readthedocs.io/[Cloud-init Official Documentation,window=_blank]
+* link:https://kubevirt.io/user-guide/[KubeVirt User Guide,window=_blank]
+


### PR DESCRIPTION
- Add cloud-init IP configuration tutorial (DHCP, static IP, multiple interfaces, VLAN)
- Add cloud-init troubleshooting guide (6 scenarios with diagnostic commands)
- Update interface naming references for accuracy (guest OS dependency)
- Add VM configuration cross-references to manifests pages
- All content reviewed and tested on OpenShift 4.20.0 cluster