### PR TITLE
Remove index from homepage

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -61,47 +61,6 @@ Each module contains step-by-step tutorials, practical examples, and troubleshoo
 In order to start, select the specific module of your interest from the menu tree on the left.
 If unsure, xref:getting-started:index.adoc[start from here].
 
-=======
-=== Getting Started
-
-* xref:getting-started:prerequisites.adoc[Prerequisites and Setup]
-* xref:getting-started:virtctl-basics.adoc[Virtctl Basics]
-* xref:getting-started:storage-setup.adoc[Configuring Default Storage Class]
-
-=== Storage
-
-* xref:storage:lvm-operator.adoc[Installing LVM Storage Operator]
-* xref:storage:lvm-troubleshooting.adoc[Troubleshooting LVM Storage Operator]
-
-=== Networking
-
-* xref:networking:udn-primary-networks.adoc[Configuring Layer 2 Primary Networks with UDNs]
-* xref:networking:localnet-secondary.adoc[Configuring Localnet Secondary Networks with ClusterUserDefinedNetwork]
-* xref:networking:localnet-vlan.adoc[Configuring Localnet Secondary Networks with VLAN using NetworkAttachmentDefinition]
-* xref:networking:cudn-localnet-vlan.adoc[Configuring Localnet Secondary Networks with VLAN using ClusterUserDefinedNetwork]
-* xref:networking:linux-bridges.adoc[Configuring Linux Bridges for VMs]
-* xref:networking:ovs-bridge-verification.adoc[Troubleshooting OVS Bridge Creation for Localnet Networks]
-
-=== Virtual Machine Configuration
-
-* xref:vm-configuration:cloud-init-ip-configuration.adoc[Cloud-init IP Configuration]
-* xref:vm-configuration:cloud-init-troubleshooting.adoc[Cloud-init Troubleshooting]
-* xref:vm-configuration:internal-dns-for-vms.adoc[Internal DNS for VMs]
-* xref:vm-configuration:remote-access-linux-vms.adoc[Remote Access to Linux VMs]
-* xref:vm-configuration:remote-access-troubleshooting.adoc[Remote Access Troubleshooting]
-* xref:vm-configuration:remote-access-windows-rdp.adoc[Remote Access to Windows VMs via RDP]
-* xref:vm-configuration:custom-golden-images.adoc[Custom Golden Images]
-* xref:vm-configuration:golden-images-troubleshooting.adoc[Golden Images Troubleshooting]
-
-=== Manifests Reference
-
-* xref:manifests:operators.adoc[Operator Manifests]
-* xref:manifests:networking.adoc[Networking Manifests]
-* xref:manifests:storage.adoc[Storage Manifests]
-* xref:manifests:vms.adoc[Virtual Machine Manifests]
-* xref:manifests:security.adoc[Security Manifests]
->>>>>>> d581823 (ADD VM DNS resoltion tutorial)
-
 == Additional Resources
 
 * xref:appendix:glossary.adoc[Glossary] - Key terms and definitions


### PR DESCRIPTION
Given all the articles are listed in the left tree menu, there no need to manually list them in the homepage.

## Description

Removed the index from the homepage.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [x] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

<!-- Link to the issue this PR addresses -->
Closes #<!-- issue number -->

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [ ] Technical details verified against official documentation
- [ ] Use Professional language

### Testing & Verification
- [ ] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [x] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [x] All internal links (xrefs) are working
- [x] All external links use `window=_blank`
- [x] Navigation (`nav.adoc`) updated if adding new pages
- [x] Home page updated if adding new module/tutorial

### Build & Preview
- [x] `npm run build` completes without errors
- [x] Local preview verified (`npm run serve`)
- [x] No broken xref warnings in build output
- [x] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made

<!-- Provide a bullet-point list of changes -->

- 
- 
- 
## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

