### PR TITLE
Update docs for OpenShift 4.18+/4.20

### DIFF
--- a/modules/getting-started/pages/prerequisites.adoc
+++ b/modules/getting-started/pages/prerequisites.adoc
@@ -9,7 +9,7 @@ This page outlines the prerequisites and requirements for working with OpenShift
 
 === OpenShift Version
 
-* OpenShift 4.17 or later
+* OpenShift 4.18+ or later
 * OpenShift Virtualization operator installed and running
 
 === Cluster Access
@@ -26,7 +26,7 @@ You'll need appropriate access levels depending on the tasks you want to perform
 
 The OpenShift command-line interface is essential for cluster interaction.
 
-Install from: link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI Documentation,window=_blank]
+Install from: link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/cli_tools/openshift-cli-oc#cli-getting-started[OpenShift CLI Documentation,window=_blank]
 
 Verify installation:
 [source,bash,role=execute]
@@ -50,7 +50,7 @@ kubectl version
 
 The virtctl tool is specifically designed for managing KubeVirt/OpenShift Virtualization resources.
 
-Install from: link:https://docs.openshift.com/container-platform/latest/virt/virt-using-the-cli-tools.html[Virtctl Documentation,window=_blank]
+Install from: link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/virtualization/getting-started#virt-using-the-cli-tools[OpenShift Virtualization Documentation,window=_blank]
 
 Verify installation:
 [source,bash,role=execute]
@@ -117,4 +117,3 @@ Once you have the prerequisites in place:
 
 * link:https://docs.openshift.com/container-platform/latest/virt/about_virt/about-virt.html[OpenShift Virtualization Documentation,window=_blank]
 * link:https://kubevirt.io/[KubeVirt Project,window=_blank]
-

--- a/modules/networking/pages/index.adoc
+++ b/modules/networking/pages/index.adoc
@@ -36,25 +36,24 @@ Before proceeding with the tutorials in this section, ensure you have:
 
 == Sections
 
-xref:udn-primary-networks.adoc[]::
-Configure Layer 2 primary networks using UDNs for namespace isolation.
+xref:udn-primary-networks.adoc[]
 
-xref:localnet-secondary.adoc[]::
-Set up localnet topology for external network connectivity using ClusterUserDefinedNetwork.
 
-xref:localnet-vlan.adoc[]::
-Configure VLAN tagging with localnet networks using NetworkAttachmentDefinition.
+xref:localnet-secondary.adoc[]
 
-xref:cudn-localnet-vlan.adoc[]::
-Configure VLAN tagging with localnet networks using ClusterUserDefinedNetwork for cross-namespace availability.
 
-xref:linux-bridges.adoc[]::
-Traditional Linux bridge networking for VMs.
+xref:localnet-vlan.adoc[]
 
-xref:ovs-bridge-troubleshooting.adoc[]::
-Verify and troubleshoot OVS bridge configurations.
 
-== Network Architecture Considerations
+xref:cudn-localnet-vlan.adoc[]
+
+
+xref:linux-bridges.adoc[]
+
+
+xref:ovs-bridge-troubleshooting.adoc[]
+
+
 
 === Primary vs Secondary Networks
 
@@ -86,6 +85,4 @@ After completing this module, you'll be ready to:
 == See Also
 
 * xref:vm-configuration:internal-dns-for-vms.adoc[Internal DNS for VMs] - Configure internal cluster DNS resolution for VMs
-* link:https://docs.openshift.com/container-platform/latest/virt/vm_networking/virt-about-vm-networking.html[OpenShift Virtualization Networking,window=_blank]
-* link:https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html[About OVN-Kubernetes,window=_blank]
-* link:https://kubevirt.io/user-guide/user_workloads/interfaces_and_networks/[KubeVirt Networking Documentation,window=_blank]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/virtualization/networking[OpenShift Virtualization Networking,window=_blank]

--- a/modules/storage/pages/index.adoc
+++ b/modules/storage/pages/index.adoc
@@ -32,7 +32,7 @@ This module focuses on LVM Storage, which is ideal for Single Node OpenShift (SN
 
 Before proceeding with the tutorials in this section, ensure you have:
 
-* OpenShift 4.14+ cluster
+* OpenShift 4.18+ cluster
 * Cluster admin access
 * At least one spare local disk on cluster nodes
 * Basic understanding of Linux storage concepts (LVM, block devices)
@@ -65,6 +65,5 @@ After completing this module, you'll be ready to:
 
 == See Also
 
-* xref:getting-started:default-storage-class.adoc
-[Configure Default Storage Class]
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/storage/persistent-storage-using-local-storage#persistent-storage-using-lvms[OpenShift LVM Storage Documentation,window=_blank]
+* xref:getting-started:default-storage-class.adoc[Configure Default Storage Class]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/storage/persistent-storage-using-local-storage#persistent-storage-using-lvms[OpenShift LVM Storage Documentation,window=_blank]

--- a/modules/vm-configuration/pages/index.adoc
+++ b/modules/vm-configuration/pages/index.adoc
@@ -49,29 +49,6 @@ Create reusable golden images with pre-configured software and settings for cons
 xref:golden-images-troubleshooting.adoc[]::
 Troubleshooting guide for creating and using custom golden images, including verification commands and common issue resolutions.
 
-== Best Practices
-
-=== Configuration Management
-
-* Use networkData for network-specific configuration
-* Keep userData for general system initialization
-* Test configurations in development before production
-* Validate YAML syntax before deployment
-
-=== Network Design
-
-* Use DHCP for ephemeral/development workloads
-* Use static IPs for production services
-* Only set default route on primary interface
-* Document IP assignments and network topology
-
-=== Security
-
-* Avoid hardcoding passwords in production
-* Use SSH keys for authentication
-* Implement network segmentation
-* Apply least privilege principles
-
 == Related Topics
 
 * xref:getting-started:index.adoc[Getting Started] - Initial setup and prerequisites
@@ -80,7 +57,7 @@ Troubleshooting guide for creating and using custom golden images, including ver
 
 == Additional Resources
 
-* link:https://docs.openshift.com/container-platform/latest/virt/about_virt/about-virt.html[OpenShift Virtualization Documentation,window=_blank]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/virtualization/about#about-virt[OpenShift Virtualization Documentation,window=_blank]
 * link:https://cloudinit.readthedocs.io/[Cloud-init Official Documentation,window=_blank]
 * link:https://kubevirt.io/user-guide/[KubeVirt User Guide,window=_blank]
 


### PR DESCRIPTION
Updates OpenShift version requirements to 4.18+, refreshes documentation links to OpenShift 4.20, and streamlines content by removing redundant descriptions.