### PR TITLE
Fix networking tutorials and update docs to OpenShift 4.20

### DIFF
--- a/modules/networking/pages/linux-bridges.adoc
+++ b/modules/networking/pages/linux-bridges.adoc
@@ -1,6 +1,11 @@
 = Adding a Bridge as a Secondary Network Adapter
 :navtitle: Linux Bridges
 
+Versions tested:
+----
+OpenShift 4.20
+----
+
 This quick-guide describes how to add a secondary Linux bridge adapter to a VM.
 A Linux bridge acts as a network switch between pods running on the same node/host machine.
 Optionally, a bridge interface can be linked to a physical host interface.
@@ -66,7 +71,7 @@ oc create namespace openshift-nmstate
 Using your favorite text editor, create the following Subscription object by copy/pasting the following yaml into a new buffer:
 
 ----
-apiGroup: operators.coreos.com/v1alpha1
+apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: nmstate-operator
@@ -167,7 +172,7 @@ metadata:
 spec:
   desiredState:
     interfaces:
-    - name: br0
+    - name: lnbr0
       description: static linux bridge with ens1 as a port
       type: linux-bridge
       state: up
@@ -181,7 +186,8 @@ spec:
         options:
           stp:
             enabled: false
-        port: ens1
+        port:
+        - name: ens1
 ----
 
 .DHCP Configuration Example
@@ -193,7 +199,7 @@ metadata:
 spec:
   desiredState:
     interfaces:
-    - name: br0
+    - name: lnbr0
       description: dhcp linux bridge with ens1 as a port
       type: linux-bridge
       state: up
@@ -204,7 +210,8 @@ spec:
         options:
           stp:
             enabled: false
-        port: ens1
+        port:
+        - name: ens1
 ----
 
 .Layer2-only Configuration Example
@@ -224,7 +231,8 @@ spec:
         options:
           stp:
             enabled: false
-        port: ens1
+        port:
+        - name: ens1
 ----
 
 Apply the NNCP yaml file that was just created to the cluster:
@@ -271,7 +279,13 @@ Neglecting to do so will prevent any VM with a bridge-based NIC from booting.
 NOTE: A namespace containing VMs must either exist or be created before proceeding.
 
 === Procedure using the CLI: [[create_nad_cli_procedure]]
-It is necessary to change to the project/namespace of the VMs before proceeding (replace `bridge-demo` with the namespace for where the VMs reside):
+First, create the namespace for your VMs if it doesn't already exist:
+
+----
+oc create namespace bridge-demo
+----
+
+Then switch to that namespace:
 
 ----
 oc project bridge-demo
@@ -317,6 +331,10 @@ Each field from the above example is explained below (optional fields are shown 
 [IMPORTANT]
 ====
 * Configuring IP address management (IPAM) in a network attachment definition for VMs is not supported, so the `"ipam": {}` definition must be empty.
+* To assign IP addresses to VM interfaces on a Linux bridge network, use one of the following methods:
+** **cloud-init networkData**: Configure static IP addresses in the VM's cloud-init configuration (recommended for predictable addressing)
+** **External DHCP server**: If a DHCP server exists on the bridge network, VMs will obtain IP addresses automatically
+** **Manual configuration**: Configure IP addresses manually inside the VM using `nmcli` or network settings after boot
 * The NAD must exist in the same namespace as the pods/VMs.
 * OpenShift Virtualization does not support https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/configuring_and_managing_networking/configuring-a-network-bond#upstream-switch-configuration-depending-on-the-bonding-modes[Linux bridge bonding modes] 0, 5, and 6.
 ====
@@ -434,7 +452,7 @@ spec:
       - name: default
         pod: {}
       - multus:
-          networkName: nad-lnbr0
+          networkName: lnbr0-nad
         name: nic-linux-bridge-0
   ...
 ----
@@ -459,3 +477,100 @@ oc apply -f bridge-example.vm.yaml
 NOTE: If you edited a running virtual machine, you must restart or live migrate it for the changes to take effect.
 
 The Linux bridge should now be visible from the VM (after a restart, as mentioned). You can use the `nmcli` tool or Windows Settings/Control Panel inside the container to configure the IP address of the bridge interface.
+
+== Complete VM Example with Static IP Configuration
+
+The following is a complete VM example that creates a new VM with a Linux bridge secondary interface and uses cloud-init to configure a static IP address:
+
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: bridge-demo-vm
+  namespace: bridge-demo
+  labels:
+    app: bridge-demo-vm
+spec:
+  runStrategy: Always
+  dataVolumeTemplates:
+  - metadata:
+      name: bridge-demo-volume
+    spec:
+      pvc:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 33Gi
+      sourceRef:
+        kind: DataSource
+        name: fedora
+        namespace: openshift-virtualization-os-images
+  template:
+    metadata:
+      labels:
+        app: bridge-demo-vm
+    spec:
+      domain:
+        devices:
+          disks:
+          - name: datavolumedisk
+            disk:
+              bus: virtio
+          - name: cloudinitdisk
+            disk:
+              bus: virtio
+          interfaces:
+          - masquerade: {}
+            name: default
+          - bridge: {}
+            model: virtio
+            name: nic-linux-bridge
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 1
+      networks:
+      - name: default
+        pod: {}
+      - multus:
+          networkName: lnbr0-nad
+        name: nic-linux-bridge
+      volumes:
+      - name: datavolumedisk
+        dataVolume:
+          name: bridge-demo-volume
+      - name: cloudinitdisk
+        cloudInitNoCloud:
+          networkData: |
+            version: 2
+            ethernets:
+              enp2s0:
+                addresses:
+                - 192.168.50.10/24
+          userData: |
+            #cloud-config
+            user: fedora
+            password: fedora
+            chpasswd: { expire: False }
+----
+
+Key points in this example:
+
+* The `networkData` section configures a static IP (`192.168.50.10/24`) on the secondary interface (`enp2s0`)
+* The primary interface (`enp1s0`) uses masquerade and gets its IP from the pod network
+* The secondary interface name `enp2s0` follows KubeVirt's predictable naming convention for the second network interface
+
+Apply this VM to the cluster:
+
+----
+oc apply -f bridge-demo-vm.yaml -n bridge-demo
+----
+
+Verify the VM is running and check its network interfaces:
+
+----
+oc get vmi -n bridge-demo
+oc get vmi bridge-demo-vm -n bridge-demo -o jsonpath='{.status.interfaces}' | jq .
+----

--- a/modules/networking/pages/localnet-secondary.adoc
+++ b/modules/networking/pages/localnet-secondary.adoc
@@ -1,6 +1,11 @@
 = Configuring Localnet Secondary Networks with ClusterUserDefinedNetwork in OpenShift Virtualization
 :navtitle: Localnet Secondary Networks with CUDN
 
+Versions tested:
+----
+OpenShift 4.20
+----
+
 This tutorial demonstrates how to configure localnet secondary networks using ClusterUserDefinedNetwork (CUDN) in OpenShift Virtualization. Localnet topology provides direct access to physical network infrastructure, enabling VMs to communicate with external networks while maintaining pod network connectivity. This approach is ideal for integrating with existing infrastructure or legacy systems requiring layer 2 connectivity.
 
 == Prerequisites

--- a/modules/networking/pages/localnet-vlan.adoc
+++ b/modules/networking/pages/localnet-vlan.adoc
@@ -82,6 +82,7 @@ spec:
     "type": "ovn-k8s-cni-overlay",
     "topology": "localnet",
     "netAttachDefName": "vm-guests-vlan/localnet-vlan-100",
+    "physicalNetworkName": "localnet-vlan",
     "vlanID": 100,
     "subnets": "192.168.100.0/24",
     "excludeSubnets": "192.168.100.1/32"
@@ -91,11 +92,11 @@ EOF
 
 **Configuration Details**:
 
+* `physicalNetworkName: "localnet-vlan"`: Links this NAD to the bridge mapping configured in the NNCP (must match the `localnet` name in the bridge-mappings)
 * `vlanID: 100`: Specifies VLAN tag 100 for network segmentation
-* `subnets`: Defines the expected IP subnet range for documentation and validation purposes
+* `subnets`: Defines the IP subnet range for OVN-Kubernetes IPAM
 * `excludeSubnets`: Excludes gateway IP from being assigned (typically reserved for router/gateway)
 * `topology: "localnet"`: Uses localnet topology for direct physical network access
-* **No IPAM configuration**: IP addresses require external DHCP server on the VLAN network or VMs need to be configured statically
 
 == Step 4: Deploy VM with VLAN Network Connectivity
 

--- a/modules/networking/pages/ovs-bridge-troubleshooting.adoc
+++ b/modules/networking/pages/ovs-bridge-troubleshooting.adoc
@@ -1,5 +1,10 @@
 = Troubleshooting OVS Bridge Creation for Localnet Networks
-:navtitle:
+:navtitle: Troubleshooting Localnet Networks
+
+Versions tested:
+----
+OpenShift 4.20
+----
 
 This guide helps you verify that OVS (Open vSwitch) bridges are correctly created and configured for localnet secondary networks in OpenShift Virtualization.
 
@@ -807,4 +812,4 @@ oc logs -n openshift-nmstate -l app=kubernetes-nmstate-operator
 
 * link:https://nmstate.io/[NMState Documentation,window=_blank]
 * link:http://www.openvswitch.org/support/dist-docs/[Open vSwitch Documentation,window=_blank]
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator[OpenShift NMState Operator,window=_blank]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator[OpenShift NMState Operator,window=_blank]

--- a/modules/networking/pages/udn-primary-networks.adoc
+++ b/modules/networking/pages/udn-primary-networks.adoc
@@ -7,7 +7,7 @@ This tutorial shows you how to create a primary network using User Defined Netwo
 
 Versions tested:
 ----
-OpenShift 4.19
+OpenShift 4.19,4.20
 ----
 
 == Step 1: Create UDN-Enabled Namespace


### PR DESCRIPTION
- Fix Linux bridges tutorial: NNCP syntax, NAD references, add VM example with cloud-init static IP
- Fix localnet-vlan NAD: add missing physicalNetworkName field
- Update all networking tutorials with tested version OpenShift 4.20
- Update documentation links to OpenShift 4.20
- Add navtitle to troubleshooting guide
- Minor fixes across storage and vm-configuration modules