### PR TITLE
Use pnpm instead of npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This section is intended as a quick start guide for technically experienced memb
 - You have a macOS or Linux workstation. Windows has not been tested, or supported. You can try using a WSL2 based environment to run these steps - YMMV!
 - You have a somewhat recent version of the Git client installed on your workstation
 - You have a somewhat new Node.js LTS release (Node.js 16+) installed locally.
+- You have [pnpm](https://pnpm.io/installation); npm will work but not recommended
 - Install a recent version of Visual Studio Code. Other editors with asciidoc editing support may work - YMMV, and you are on your own...
 
 ### Antora Files and Folder Structure
@@ -39,23 +40,23 @@ To add a new section under a chapter create an entry in the _modules/CHAPTER/nav
 $ git clone git@github.com:RedHatQuickCourses/ocp-virt-cookbook.git
 ```
 
-2. Install the npm dependencies for the course tooling.
+2. Install the pnpm dependencies for the course tooling.
 
 ```
 $ cd ocp-virt-cookbook
-$ npm install
+$ pnpm install
 ```
 
 3. Start the asciidoc to HTML compiler in the background. This command watches for changes to the asciidoc source content in the **modules** folder and automatically re-generates the HTML content.
 
 ```
-$ npm run watch:adoc
+$ pnpm run watch:adoc
 ```
 
 4. Start a local web server to serve the generated HTML files. Navigate to the URL printed by this command to preview the generated HTML content in a web browser.
 
 ```
-$ npm run serve
+$ pnpm run serve
 ```
 
 5. Before you make any content changes, create a local Git branch based on the **main** branch. As a good practice, prefix the branch name with your GitHub ID. Use a suitable branch naming scheme that reflects the content you are creating or changing.

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -36,7 +36,7 @@ commands:
   - id: 0-install
     exec:
       component: runtime
-      commandLine: npm install
+      commandLine: pnpm install
       workingDir: ${PROJECT_SOURCE}
       group:
         kind: build
@@ -44,7 +44,7 @@ commands:
   - id: 1-watch
     exec:
       component: runtime
-      commandLine: npm run watch:adoc
+      commandLine: pnpm run watch:adoc
       workingDir: ${PROJECT_SOURCE}
       group:
         kind: run
@@ -52,7 +52,7 @@ commands:
   - id: 2-serve
     exec:
       component: runtime
-      commandLine: npm run serve
+      commandLine: pnpm run serve
       workingDir: ${PROJECT_SOURCE}
       group:
         kind: run

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "antora antora-playbook.yml",
-    "watch:adoc": "watch 'npx antora antora-playbook.yml' ./modules",
-    "serve": "npx http-server build/site -c-1"
+    "watch:adoc": "watch 'pnpm dlx antora antora-playbook.yml' ./modules",
+    "serve": "pnpm dlx http-server build/site -c-1"
   }
 }

--- a/pdfgen.sh
+++ b/pdfgen.sh
@@ -9,7 +9,7 @@
 ## - Images included in the content are not rendered in the generated PDF.
 ##
 ## TODO:
-## - A better alternative would be to use one of Antora's official npm packages for PDF generation.
+## - A better alternative would be to use one of Antora's official pnpm packages for PDF generation.
 
 count=1
 filename=$(basename $(pwd)).pdf


### PR DESCRIPTION
## Description

With the amount of security issues recently with use of npm it is recommended to use pnpm instead.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [x] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

<!-- Link to the issue this PR addresses -->
Closes #39

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [ ] Technical details verified against official documentation
- [ ] Use Professional language

### Testing & Verification
- [ ] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [ ] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [ ] All internal links (xrefs) are working
- [ ] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

### Build & Preview
- [x] `pnpm run build` completes without errors
- [x] Local preview verified (`pnpm run serve`)
- [x] No broken xref warnings in build output
- [x] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made

<!-- Provide a bullet-point list of changes -->

- updated references to npm to use pnpm instead
- updated references to npx to use pnpm dlx instead

## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

