### PR TITLE
Add macOS files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,30 @@
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+
+# macOS Thumbnails
+Icon
+
+# macOS Finder
+.Spotlight-V100
+.Trashes
+
+# macOS directory metadata
+.fseventsd
+.DocumentRevisions-V100
+.TemporaryItems
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# macOS Network and AppleDouble
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
Add standard macOS system files (.DS_Store, resource forks, Spotlight index, etc.) to prevent tracking OS-generated metadata.