### PR TITLE
Added gitignore exclusion for html files generated by Asciidoctor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ dist
 
 # Cursor AI project files
 .cursor/
+
+# HTML files rendered with Asciidoctor
+*.html


### PR DESCRIPTION
## Description

Updated `.gitignore` to exclude html files generated using the [Asciidoctor](https://asciidoctor.org) utility.

## Type of Change

Fix / enhancement (no content updates)

