### PR TITLE
Fix duplicate entries and reorder getting-started navigation

### DIFF
--- a/modules/getting-started/nav.adoc
+++ b/modules/getting-started/nav.adoc
@@ -1,8 +1,6 @@
 * xref:index.adoc[]
 ** xref:prerequisites.adoc[]
 ** xref:install-openshift-virtualization.adoc[]
-** xref:create-vm-web-console.adoc[]
-** xref:virtctl-basics.adoc[]
 ** xref:default-storage-class.adoc[]
 ** xref:create-vm-web-console.adoc[]
 ** xref:virtctl-basics.adoc[]


### PR DESCRIPTION
## Summary
- Remove duplicate navigation links for create-vm-web-console and virtctl-basics
- Reorder navigation to logical flow: prerequisites, install, storage setup, then VM creation and CLI basics

## Test plan
- [ ] Verify site builds without errors
- [ ] Check navigation renders correctly in preview