### PR TITLE
Replace deprecated spec.running with spec.runStrategy in VM manifests

### DIFF
--- a/modules/getting-started/pages/default-storage-class.adoc
+++ b/modules/getting-started/pages/default-storage-class.adoc
@@ -175,7 +175,7 @@ metadata:
   name: test-vm-default-storage
   namespace: default
 spec:
-  running: true
+  runStrategy: Always
   dataVolumeTemplates:
   - metadata:
       name: test-vm-disk

--- a/modules/networking/attachments/udn-primary-networks/fedora-vm-with-udn.yaml
+++ b/modules/networking/attachments/udn-primary-networks/fedora-vm-with-udn.yaml
@@ -7,7 +7,7 @@ metadata:
     app: fedora-web-vm
     network-type: udn-primary
 spec:
-  running: true
+  runStrategy: Always
   dataVolumeTemplates:
   - metadata:
       name: fedora-udn-volume

--- a/modules/networking/pages/udn-primary-networks.adoc
+++ b/modules/networking/pages/udn-primary-networks.adoc
@@ -82,7 +82,7 @@ metadata:
     app: fedora-web-vm
     network-type: udn-primary
 spec:
-  running: true
+  runStrategy: Always
   dataVolumeTemplates:
   - metadata:
       name: fedora-udn-volume


### PR DESCRIPTION
- Replace deprecated `running: true` with `runStrategy: Always` in the UDN primary networks tutorial
- Update the downloadable `fedora-vm-with-udn.yaml` attachment to match the tutorial page
- Fix the same deprecation in the default storage class tutorial VM manifest
- Eliminate the `spec.running is deprecated` warning on OpenShift 4.21+
- Ensure all VirtualMachine manifests in the cookbook use the current KubeVirt API field

Closes #135