### PR TITLE
Remove PR comment step from doc-review workflow

### DIFF
--- a/.github/workflows/doc-review.yml
+++ b/.github/workflows/doc-review.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -34,53 +33,6 @@ jobs:
 
       - name: Run documentation review
         if: steps.changed.outputs.empty == 'false'
-        id: review
-        continue-on-error: true
         env:
           FILES: ${{ steps.changed.outputs.files }}
-        run: |
-          set +e
-          OUTPUT=$(bash scripts/review-docs.sh $FILES 2>&1)
-          EXIT_CODE=$?
-          {
-            echo "output<<REVIEW_EOF"
-            echo "$OUTPUT"
-            echo "REVIEW_EOF"
-          } >> $GITHUB_OUTPUT
-          echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
-          exit $EXIT_CODE
-
-      - name: Comment on PR
-        if: always() && steps.changed.outputs.empty == 'false'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const status = '${{ steps.review.outputs.exit_code }}' === '0' ? '[PASSED]' : '[FAILED]';
-            const body = `### Documentation Review ${status}\n\n\`\`\`\n${process.env.REVIEW_OUTPUT}\n\`\`\``;
-
-            // Delete previous review comments
-            const { data: comments } = await github.rest.issues.listComments({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo
-            });
-
-            for (const comment of comments) {
-              if (comment.body.startsWith('### Documentation Review')) {
-                await github.rest.issues.deleteComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: comment.id
-                });
-              }
-            }
-
-            // Create new comment
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            });
-        env:
-          REVIEW_OUTPUT: ${{ steps.review.outputs.output }}
+        run: bash scripts/review-docs.sh $FILES


### PR DESCRIPTION
- Remove the Comment on PR step that fails with 403 on fork-based PRs
- Let the review script exit code directly determine the check pass/fail status
- Simplify the review step by removing output capture only needed for commenting
- Drop the pull-requests: write permission that is no longer required
- Review output remains visible in the Actions log for anyone who needs details