### PR TITLE
Fixed incorrect file name reference within a paragraph

### DIFF
--- a/modules/networking/pages/linux-bridges.adoc
+++ b/modules/networking/pages/linux-bridges.adoc
@@ -54,7 +54,7 @@ You can, however control which nodes that the `nncp` applies to using key-value 
 * If you skip the `nncp` creation and try to boot a VM with a secondary bridge adapter, it will fail to start.
 ====
 
-Copy and paste the following `NodeNetworkConfigurationPolicy` into a new file named `lnbr0-bridge.net-attach-def.yaml`.
+Copy and paste the following `NodeNetworkConfigurationPolicy` into a new file named `lnbr0-bridge.nncp.yaml`.
 To connect to external networks, you'll need to uncomment the last two lines, changing the device name to match the secondary or tertiary (if primary & secondary are bonded) device name on the node(s):
 
 [source,yaml]


### PR DESCRIPTION
## Description

<!-- Provide a brief description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (broken link, incorrect command, typo)

## Related Issue

<!-- Link to the issue this PR addresses -->
Closes #243 

## Changes Made

<!-- Provide a bullet-point list of changes -->

- Incorrect filename reference (within a paragraph, not an actual command) was corrected within the opening steps of the guide (L57). 

## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

Thanks again to Adriel Mendez for reviewing the document and reporting the bug!

