### PR TITLE
clarify `scheduling` tab location in ocpv webconsole

### DIFF
--- a/modules/vm-configuration/pages/node-placement-affinity.adoc
+++ b/modules/vm-configuration/pages/node-placement-affinity.adoc
@@ -719,7 +719,8 @@ spec:
 
 . Navigate to **Virtualization** -> **VirtualMachines**
 . Click on a VM to view details
-. Go to the **Scheduling** tab
+. Click on the **Configuration** tab
+. Go to the **Scheduling** subtab
 . View configured node selectors, affinity, and tolerations
 . Check the **Overview** tab to see which node the VM is running on
 


### PR DESCRIPTION
## Description

The steps to get to a virtual machines `scheduling` tab was a bit ambiguous. it is not a top-level tab rather a subtab inside the `Configuration` top-level tab. This PR clarifies its location.

## Type of Change

- [ ] New tutorial/content
- [ ] Bug fix (broken link, incorrect command, typo)
- [x] Enhancement to existing content
- [x] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

<!-- Link to the issue this PR addresses -->
Closes #<!-- issue number -->

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [ ] Technical details verified against official documentation
- [ ] Use Professional language

### Testing & Verification
- [x] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [x] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [ ] All internal links (xrefs) are working
- [ ] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

### Build & Preview
- [x] `npm run build` completes without errors
- [x] Local preview verified (`npm run serve`)
- [ ] No broken xref warnings in build output
- [ ] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made

<!-- Provide a bullet-point list of changes -->

- modules/vm-configuration/pages/node-placement-affinity.adoc
  - added one more step `click on the Configuration tab`
  - changed wording on step 4 from `tab` to `subtab`
## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

