### PR TITLE
Add more OCP-V content reference (#247)

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -34,7 +34,12 @@ Select one of the module from the left menu to begin:
 
 == Additional Resources
 
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/virtualization/about[OpenShift Virtualization Documentation,window=_blank]
+* OpenShift Virtualization
+** link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/virtualization/about[Official Documentation,window=_blank]
+** link:https://www.redhat.com/en/technologies/cloud-computing/openshift/virtualization/learn[Learning hub,window=_blank]
+** link:https://access.redhat.com/sites/default/files/attachments/openshift_virtualization_reference_implementation_guide.pdf[Reference Implementation Guide (pdf),window=_blank]
+** link:https://access.redhat.com/articles/7119411[Architecture Guide,window=_blank]
+** link:https://access.redhat.com/articles/7067871[Example Architectures,window=_blank]
 * link:https://kubevirt.io/[KubeVirt Project,window=_blank]
 * link:https://cloudinit.readthedocs.io/[Cloud-init Documentation,window=_blank]
 * xref:appendix:glossary.adoc[Glossary] - Key terms and definitions


### PR DESCRIPTION
## Description

Added more OpenShift Virtualization reference architectures/learning path.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [ ] Bug fix (broken link, incorrect command, typo)
- [x] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

<!-- Link to the issue this PR addresses -->
Closes #247 

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [x] Technical details verified against official documentation
- [x] Use Professional language

### Testing & Verification
- [ ] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [x] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [x] All internal links (xrefs) are working
- [x] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

### Build & Preview
- [x] `npm run build` completes without errors
- [x] Local preview verified (`npm run serve`)
- [x] No broken xref warnings in build output
- [ ] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made

<!-- Provide a bullet-point list of changes -->

- 
- 
- 
## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

