### PR TITLE
fixed broken command output on zsh environments

### DIFF
--- a/modules/vm-configuration/pages/vm-templates.adoc
+++ b/modules/vm-configuration/pages/vm-templates.adoc
@@ -41,7 +41,7 @@ There are several topics covered step-by-step in this guide, in the following or
 
 Completing this guide will require the following:
 
-* A bash compatible shell environment.
+* A bash or compatible shell environment (zsh was also tested).
 * The OpenShift client tool, `oc`.
 * An OpenShift cluster with OpenShift Virtualization installed.
 * A text (or code) editor or IDE application.
@@ -81,7 +81,7 @@ rhel9-highperformance-medium                  Template for Red Hat Enterprise Li
 rhel9-highperformance-small                   Template for Red Hat Enterprise Linux 9 VM or newer. A PVC with the RHEL disk...   4 (2 generated)   1
 rhel9-highperformance-tiny                    Template for Red Hat Enterprise Linux 9 VM or newer. A PVC with the RHEL disk...   4 (2 generated)   1
 rhel9-server-large                            Template for Red Hat Enterprise Linux 9 VM or newer. A PVC with the RHEL disk...   4 (2 generated)   1
-rhel9-server-medium                           Template for Red Hat Enterprise Linux 9 VM or newer. A PVC with the RHEL disk...   4 (2 generated)   1 
+rhel9-server-medium                           Template for Red Hat Enterprise Linux 9 VM or newer. A PVC with the RHEL disk...   4 (2 generated)   1
 rhel9-server-small                            Template for Red Hat Enterprise Linux 9 VM or newer. A PVC with the RHEL disk...   4 (2 generated)   1
 rhel9-server-tiny                             Template for Red Hat Enterprise Linux 9 VM or newer. A PVC with the RHEL disk...   4 (2 generated)   1
 ...
@@ -334,9 +334,16 @@ The `DataVolume` should show as `PendingPopulation` and the `VirtualMachine` sho
 
 Create a shell variable to contain the name of the `rhel9-server` VM that was just created:
 
-[souce,bash,role=execute]
+[source,bash,role=execute]
 ----
-export RHEL9_SERVER_VM=$(oc get vm -o custom-columns=:metadata.name -n template-example)
+export RHEL9_SERVER_VM=$(oc get vm -o custom-columns=:metadata.name --no-headers -n template-example)
+----
+
+Check the variable to make sure the VM name is correct, and that the variable is not empty. You should see a value like `rhel9-abcdef0987654321`.
+
+[source,bash,role=execute]
+----
+echo $RHEL9_SERVER_VM
 ----
 
 You could issue a start command against the VM using `virtctl` (replace the VM name below):
@@ -553,6 +560,8 @@ Below is the list of changes from the original version of the `rhel9-server-medi
 * **`CLOUD_INIT_USERNAME`** - This is a new parameter which templatizes the cloud-init user account name, which was previously hard-coded as `cloud-user`.
 * **`CLOUD_INIT_PASSWORD`** - The name of this parameter was adjusted for clarity, since there is no longer a `cloud-user` account.
 
+IMPORTANT: Before proceeding, you must update the `rhel9-custom.template.yaml` file with the yaml data provided above.
+
 With the custom template finalized, test that it renders correctly by using `oc process`:
 
 [source,bash,role=execute]
@@ -586,7 +595,7 @@ Create a shell variable for the `rhel9-custom` VM with the following command:
 
 [source,bash,role=execute]
 ----
-export RHEL9_CUSTOM_VM=$(oc get vm -o custom-columns=:metadata.name -n template-example | grep custom)
+export RHEL9_CUSTOM_VM=$(oc get vm -o custom-columns=:metadata.name --no-headers -n template-example | grep custom)
 ----
 
 NOTE: If you wish to connect to the original `rhel9` VM that we created, replace `$RHEL9_CUSTOM_VM` with `RHEL9_SERVER_VM` in the following example)


### PR DESCRIPTION
## Description

<!-- Provide a brief description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [x] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

<!-- Link to the issue this PR addresses -->
Closes #<!-- issue number -->

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [x] All commands have been tested on a live cluster
- [x] YAML manifests are complete and valid (not partial snippets)
- [x] Technical details verified against official documentation
- [x] Use Professional language

### Testing & Verification
- [x] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [x] All verification commands produce expected outputs
- [n/a] Screenshots/outputs included (if applicable)

### Content Quality
- [x] AsciiDoc syntax is correct
- [x] Code blocks specify language (e.g., `[source,yaml]`)
- [x] All internal links (xrefs) are working
- [x] All external links use `window=_blank`
- [n/a] Navigation (`nav.adoc`) updated if adding new pages
- [n/a] Home page updated if adding new module/tutorial

### Build & Preview
- [x] `npm run build` completes without errors
- [x] Local preview verified (`npm run serve`)
- [x] No broken xref warnings in build output
- [x] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made

<!-- Provide a bullet-point list of changes -->

- 
- 
- 
## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

