### PR TITLE
Add cloud-init fundamentals tutorial for getting-started module

### DIFF
--- a/modules/getting-started/attachments/cloud-init-secret-vm.yaml
+++ b/modules/getting-started/attachments/cloud-init-secret-vm.yaml
@@ -1,0 +1,83 @@
+---
+# Secret containing cloud-init userData
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-vm-cloud-init
+  namespace: demo
+type: Opaque
+stringData:
+  userdata: |
+    #cloud-config
+    ssh_pwauth: true
+    user:
+      name: fedora
+      lock_passwd: false
+      plain_text_passwd: s3cur3p4ss
+      ssh_authorized_keys:
+        - 'ssh-ed25519 AAAA...PelXA89RIUOn/b'
+    users:
+      - name: userone
+        lock_passwd: false
+        plain_text_passwd: s3cur3p4ss
+        ssh_authorized_keys:
+          - 'ssh-ed25519 AAAA...PelXA89RIUOn/b'
+    packages:
+      - vim
+      - git
+    runcmd:
+      - echo "Cloud-init complete" > /tmp/cloud-init-done
+---
+# VirtualMachine referencing the Secret for cloud-init data
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora-cloud-init-secret-demo
+  namespace: demo
+  labels:
+    app: fedora-cloud-init-secret-demo
+spec:
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        app: fedora-cloud-init-secret-demo
+    spec:
+      domain:
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - masquerade: {}
+              name: default
+        resources:
+          requests:
+            memory: 2Gi
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - dataVolume:
+            name: fedora-cloud-init-secret-demo
+          name: rootdisk
+        - cloudInitNoCloud:
+            secretRef:
+              name: my-vm-cloud-init
+          name: cloudinitdisk
+  dataVolumeTemplates:
+    - metadata:
+        name: fedora-cloud-init-secret-demo
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: fedora
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources:
+            requests:
+              storage: 30Gi

--- a/modules/getting-started/attachments/minimal-cloud-init-vm.yaml
+++ b/modules/getting-started/attachments/minimal-cloud-init-vm.yaml
@@ -1,0 +1,70 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora-cloud-init-demo
+  namespace: demo
+  labels:
+    app: fedora-cloud-init-demo
+spec:
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        app: fedora-cloud-init-demo
+    spec:
+      domain:
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - masquerade: {}
+              name: default
+        resources:
+          requests:
+            memory: 2Gi
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - dataVolume:
+            name: fedora-cloud-init-demo
+          name: rootdisk
+        - cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              ssh_pwauth: true
+              user:
+                name: fedora
+                lock_passwd: false
+                plain_text_passwd: s3cur3p4ss
+                ssh_authorized_keys:
+                  - 'ssh-ed25519 AAAA...PelXA89RIUOn/b'
+              users:
+                - name: userone
+                  lock_passwd: false
+                  plain_text_passwd: s3cur3p4ss
+                  ssh_authorized_keys:
+                    - 'ssh-ed25519 AAAA...PelXA89RIUOn/b'
+              packages:
+                - vim
+                - git
+              runcmd:
+                - echo "Cloud-init complete" > /tmp/cloud-init-done
+          name: cloudinitdisk
+  dataVolumeTemplates:
+    - metadata:
+        name: fedora-cloud-init-demo
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: fedora
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources:
+            requests:
+              storage: 30Gi

--- a/modules/getting-started/nav.adoc
+++ b/modules/getting-started/nav.adoc
@@ -5,3 +5,4 @@
 ** xref:create-vm-web-console.adoc[]
 ** xref:vm-lifecycle-states.adoc[]
 ** xref:virtctl-basics.adoc[]
+** xref:cloud-init-fundamentals.adoc[]

--- a/modules/getting-started/pages/cloud-init-fundamentals.adoc
+++ b/modules/getting-started/pages/cloud-init-fundamentals.adoc
@@ -1,0 +1,514 @@
+= Cloud-init Fundamentals for OpenShift Virtualization VMs
+:navtitle: Cloud-init Fundamentals
+
+== Overview
+
+Cloud-init is the industry-standard tool for automating virtual machine initialization at first boot.
+In OpenShift Virtualization, nearly every VM uses cloud-init to configure users, set passwords, inject SSH keys, install packages, and assign network addresses.
+This tutorial introduces how cloud-init works, how KubeVirt delivers it to VMs, and how to embed cloud-init configuration in your VirtualMachine manifests.
+
+=== What You'll Learn
+
+* What cloud-init is and why it matters for VM automation
+* The three cloud-init data types: userData, networkData, and metadata
+* How KubeVirt delivers cloud-init data to VMs via the NoCloud datasource
+* Common cloud-config modules for user creation, package installation, and script execution
+* Two patterns for embedding cloud-init in VirtualMachine manifests (inline vs Secret reference)
+* How to verify cloud-init ran successfully
+
+Versions tested:
+[source,text]
+----
+OpenShift 4.18+
+----
+
+== Prerequisites
+
+* OpenShift 4.18+ with OpenShift Virtualization installed
+* `oc` and `virtctl` CLI tools installed (see xref:virtctl-basics.adoc[])
+* Basic understanding of YAML syntax
+* Familiarity with creating VMs (see xref:create-vm-web-console.adoc[])
+
+== What is Cloud-init?
+
+Cloud-init is an open-source framework that runs inside a virtual machine during its first boot.
+It reads configuration data from an external source and uses it to automate tasks that would otherwise require manual setup: creating user accounts, configuring SSH access, installing packages, writing configuration files, and running scripts.
+
+Cloud-init is supported by most Linux distributions including Fedora, RHEL, CentOS, Ubuntu, and Debian.
+It is the standard initialization mechanism across major cloud platforms (AWS, Azure, GCP) and virtualization platforms including KubeVirt, which powers OpenShift Virtualization.
+
+NOTE: Cloud-init only runs during the VM's first boot by default. Subsequent reboots skip cloud-init unless the instance data is explicitly cleared.
+
+== How KubeVirt Delivers Cloud-init
+
+In traditional cloud environments, VMs retrieve cloud-init data from a metadata service (an HTTP endpoint at `169.254.169.254`).
+KubeVirt uses a different approach called the *NoCloud datasource*.
+
+With NoCloud, KubeVirt:
+
+. Reads cloud-init data from the VirtualMachine manifest (or from a referenced Secret)
+. Packages the data onto a virtual disk formatted as an ISO image
+. Attaches the disk to the VM via a virtio device
+. Cloud-init inside the guest OS detects the disk, reads the data, and applies the configuration
+
+This means cloud-init configuration is self-contained within your Kubernetes resources — no external metadata service is needed.
+
+[source,yaml]
+----
+spec:
+  template:
+    spec:
+      volumes:
+        - name: cloudinitdisk
+          cloudInitNoCloud:        # <1>
+            userData: |
+              #cloud-config
+              ssh_pwauth: true
+              user:
+                name: fedora
+                lock_passwd: false
+                plain_text_passwd: changeme
+----
+<1> The `cloudInitNoCloud` volume type tells KubeVirt to create a NoCloud datasource disk.
+
+== Cloud-init Data Types
+
+Cloud-init accepts three types of configuration data. In KubeVirt, these map to fields under the `cloudInitNoCloud` volume.
+
+=== userData (cloud-config)
+
+The primary configuration channel. userData contains a *cloud-config* document — a YAML file that begins with the `#cloud-config` header. This is where you define users, packages, scripts, files, and most VM customization.
+
+[source,yaml]
+----
+cloudInitNoCloud:
+  userData: |
+    #cloud-config
+    ssh_pwauth: true
+    user:
+      name: fedora
+      lock_passwd: false
+      plain_text_passwd: s3cur3p4ss
+      ssh_authorized_keys:
+        - ssh-ed25519 AAAA... user@workstation
+    packages:
+      - vim
+      - tmux
+----
+
+IMPORTANT: The `#cloud-config` header on the first line is mandatory. Without it, cloud-init will not recognize the data as a cloud-config document and will silently skip processing.
+
+=== networkData (network-config v2)
+
+Network configuration for VM interfaces. Uses the Netplan-compatible *network-config version 2* format. Use this when you need static IPs, custom DNS, or multi-interface setups.
+
+A simple DHCP configuration:
+
+[source,yaml]
+----
+cloudInitNoCloud:
+  networkData: |
+    version: 2
+    ethernets:
+      enp1s0:
+        dhcp4: true
+----
+
+A static IP configuration with DNS and routes:
+
+[source,yaml]
+----
+cloudInitNoCloud:
+  networkData: |
+    version: 2
+    ethernets:
+      enp1s0:
+        addresses:
+          - 192.168.1.100/24             # <1>
+        nameservers:
+          addresses:
+            - 192.168.1.1
+            - 8.8.8.8                    # <2>
+        routes:
+          - to: default
+            via: 192.168.1.1             # <3>
+          - to: 10.0.0.0/8
+            via: 192.168.1.254           # <4>
+----
+<1> Static IP address with subnet mask in CIDR notation.
+<2> DNS resolver addresses.
+<3> Default gateway defined as a route (`gateway4` is deprecated).
+<4> Additional route for reaching the `10.0.0.0/8` network via a specific gateway.
+
+You can also match interfaces by MAC address instead of name, which is useful when interface names are unpredictable:
+
+[source,yaml]
+----
+cloudInitNoCloud:
+  networkData: |
+    version: 2
+    ethernets:
+      primary:
+        match:
+          macaddress: "52:54:00:12:34:56"
+        addresses:
+          - 192.168.1.100/24
+        routes:
+          - to: default
+            via: 192.168.1.1
+----
+
+NOTE: In KubeVirt VMs, the first interface is typically `enp1s0`, the second `enp2s0`, and so on. These names correspond to the order interfaces are defined in the VirtualMachine spec, not the order of NetworkAttachmentDefinitions.
+
+For multi-interface setups, VLANs, and advanced scenarios, see xref:networking:static-ip-configuration.adoc[Static IP Configuration].
+
+=== metadata
+
+VM instance metadata such as `instance-id` and `local-hostname`. In most cases, KubeVirt populates metadata automatically from the VirtualMachine resource, so you rarely need to set it manually.
+
+[source,yaml]
+----
+cloudInitNoCloud:
+  metadata: |
+    instance-id: my-vm-001
+    local-hostname: my-vm
+----
+
+TIP: If you only need to set the hostname, use the `hostname` module in userData instead of providing custom metadata.
+
+== Cloud-init Execution Stages
+
+Cloud-init runs in five stages during the boot process. Understanding these stages helps you predict when your configuration takes effect.
+
+[cols="1,2,2",options="header"]
+|===
+|Stage |When It Runs |What Happens
+
+|Generator
+|Very early boot (systemd generator)
+|Determines whether cloud-init should run at all
+
+|Local
+|Before networking is up
+|Applies network configuration from networkData
+
+|Network
+|After networking is available
+|Fetches remaining datasource information, sets hostname
+
+|Config
+|After network stage
+|Runs configuration modules: creates users, writes files, installs SSH keys
+
+|Final
+|Near end of boot
+|Runs `runcmd` commands, installs packages, executes final scripts
+|===
+
+This ordering means that network configuration (from networkData) is applied before user configuration (from userData modules). Commands specified in `runcmd` run last, after all other modules.
+
+== Common Cloud-config Modules
+
+The following modules cover the most common VM initialization tasks. Each example shows the relevant section of a `#cloud-config` userData document.
+
+=== Creating Users and Setting Passwords
+
+[source,yaml]
+----
+#cloud-config
+ssh_pwauth: true
+user:
+  name: fedora
+  lock_passwd: false
+  plain_text_passwd: s3cur3p4ss
+  ssh_authorized_keys:
+    - ssh-ed25519 AAAA...key-data... user@workstation
+----
+
+The `user` key configures the default user. Set `lock_passwd: false` and `plain_text_passwd` to allow password login. Add `ssh_pwauth: true` at the top level to enable SSH password authentication (many cloud images disable it by default).
+
+For additional users beyond the default, use the `users` list:
+
+[source,yaml]
+----
+#cloud-config
+users:
+  - name: admin
+    groups: wheel
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAA...key-data...
+  - name: developer
+    shell: /bin/bash
+----
+
+=== Installing Packages
+
+[source,yaml]
+----
+#cloud-config
+package_update: true
+packages:
+  - vim
+  - git
+  - tmux
+  - python3
+----
+
+NOTE: Package installation runs during the *final* stage. The VM will be accessible via console before packages finish installing.
+
+=== Running Commands
+
+[source,yaml]
+----
+#cloud-config
+runcmd:
+  - systemctl enable --now cockpit.socket
+  - echo "VM initialized at $(date)" >> /var/log/vm-init.log
+----
+
+Commands run sequentially during the *final* stage. Each entry can be a string (run via `/bin/sh`) or a list (executed directly).
+
+=== Writing Files
+
+[source,yaml]
+----
+#cloud-config
+write_files:
+  - path: /etc/motd
+    content: |
+      Welcome to the OpenShift Virtualization VM.
+      Managed by cloud-init.
+    permissions: '0644'
+  - path: /etc/myapp/config.yaml
+    content: |
+      database: postgres
+      port: 5432
+    owner: root:root
+    permissions: '0600'
+----
+
+TIP: Files written by `write_files` are created during the *config* stage, before `runcmd` executes. This makes it safe to write a configuration file and then start a service that depends on it in `runcmd`.
+
+== Embedding Cloud-init in VirtualMachine Manifests
+
+There are two patterns for providing cloud-init data to a VirtualMachine.
+
+=== Inline cloudInitNoCloud
+
+The simplest approach — embed cloud-init data directly in the VirtualMachine manifest.
+
+xref:attachment$minimal-cloud-init-vm.yaml[Download minimal-cloud-init-vm.yaml]
+
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora-cloud-init-demo
+  namespace: demo
+spec:
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        app: fedora-cloud-init-demo
+    spec:
+      domain:
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - masquerade: {}
+              name: default
+        resources:
+          requests:
+            memory: 2Gi
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - dataVolume:
+            name: fedora-cloud-init-demo
+          name: rootdisk
+        - cloudInitNoCloud:                    # <1>
+            userData: |                        # <2>
+              #cloud-config
+              ssh_pwauth: true
+              user:
+                name: fedora
+                lock_passwd: false
+                plain_text_passwd: s3cur3p4ss
+                ssh_authorized_keys:
+                  - 'ssh-ed25519 AAAA...your-key... user@workstation'
+              users:
+                - name: userone
+                  lock_passwd: false
+                  plain_text_passwd: s3cur3p4ss
+                  ssh_authorized_keys:
+                    - 'ssh-ed25519 AAAA...your-key... user@workstation'
+              packages:
+                - vim
+                - git
+              runcmd:
+                - echo "Cloud-init complete" > /tmp/cloud-init-done
+          name: cloudinitdisk
+  dataVolumeTemplates:
+    - metadata:
+        name: fedora-cloud-init-demo
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: fedora
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources:
+            requests:
+              storage: 30Gi
+----
+<1> The `cloudInitNoCloud` volume type creates the NoCloud datasource disk.
+<2> The `userData` field contains the cloud-config YAML, starting with `#cloud-config`.
+
+This pattern works well for simple configurations. For larger or sensitive configurations, use a Secret reference.
+
+=== Secret Reference
+
+For complex configurations or when cloud-init data contains sensitive values (passwords, tokens), store the data in a Kubernetes Secret and reference it from the VirtualMachine.
+
+xref:attachment$cloud-init-secret-vm.yaml[Download cloud-init-secret-vm.yaml]
+
+First, create the Secret:
+
+[source,bash,role=execute]
+----
+oc create secret generic my-vm-cloud-init \
+  --from-literal=userdata='#cloud-config
+ssh_pwauth: true
+user:
+  name: fedora
+  lock_passwd: false
+  plain_text_passwd: s3cur3p4ss
+  ssh_authorized_keys:
+    - ssh-ed25519 AAAA...your-key... user@workstation
+users:
+  - name: userone
+    lock_passwd: false
+    plain_text_passwd: s3cur3p4ss
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAA...your-key... user@workstation
+packages:
+  - vim
+  - git
+' \
+  -n demo
+----
+
+Then reference it in the VirtualMachine manifest:
+
+[source,yaml]
+----
+volumes:
+  - cloudInitNoCloud:
+      secretRef:
+        name: my-vm-cloud-init         # <1>
+    name: cloudinitdisk
+----
+<1> KubeVirt reads the `userdata` key from the Secret and delivers it as the cloud-init userData.
+
+== Verifying Cloud-init Ran
+
+After your VM boots, verify that cloud-init processed the configuration successfully.
+
+Access the VM console:
+
+[source,bash,role=execute]
+----
+virtctl console fedora-cloud-init-demo -n demo
+----
+
+Check cloud-init status:
+
+[source,bash,role=execute]
+----
+cloud-init status --long
+----
+
+Expected output for a successful run:
+
+[source,text]
+----
+status: done
+extended_status: done
+boot_status_code: enabled-by-generator
+detail:
+DataSourceNoCloud [seed=/dev/vdb]
+----
+
+If cloud-init reports errors, check the logs:
+
+[source,bash,role=execute]
+----
+cat /var/log/cloud-init.log | tail -50
+----
+
+For detailed diagnostic procedures and solutions to common issues, see xref:networking:cloud-init-troubleshooting.adoc[Cloud-init Troubleshooting].
+
+== Common Mistakes
+
+*Missing `#cloud-config` header*::
+The first line of userData must be exactly `#cloud-config`. Without it, cloud-init ignores the entire userData block with no error message.
+
+*YAML indentation errors*::
+Cloud-config is YAML. Inconsistent indentation (mixing tabs and spaces, wrong nesting depth) causes parse failures. Use `cloud-init devel schema --config-file /path/to/config.yaml` inside a VM to validate syntax.
+
+*Putting network config in userData*::
+Network interface configuration belongs in `networkData`, not `userData`. Placing network-config v2 YAML inside userData has no effect.
+
+*Expecting cloud-init to re-run on reboot*::
+Cloud-init runs once on first boot. To re-run it, you must clear its state: `cloud-init clean` followed by a reboot.
+
+*Wrong Secret key name*::
+When using `secretRef`, the Secret must contain a key named `userdata` (all lowercase). A key named `userData` or `user-data` will not be found.
+
+== Windows VMs: Sysprep
+
+Cloud-init is a Linux-specific tool. For Windows VMs, OpenShift Virtualization supports *Sysprep* — the Microsoft System Preparation tool that performs similar first-boot customization (hostname, administrator password, domain join, unattended setup).
+
+For Windows VM configuration, see xref:vm-configuration:remote-access-windows-vms.adoc[Remote Access to Windows VMs].
+
+== Cleanup
+
+Remove the demo resources created in this tutorial:
+
+[source,bash,role=execute]
+----
+oc delete vm fedora-cloud-init-demo -n demo
+oc delete vm fedora-cloud-init-secret-demo -n demo
+oc delete secret my-vm-cloud-init -n demo
+oc delete namespace demo
+----
+
+== Summary
+
+In this tutorial you learned:
+
+* Cloud-init is the standard Linux VM initialization framework, running at first boot to automate configuration
+* KubeVirt delivers cloud-init data via the NoCloud datasource, packaging it as a virtio disk attached to the VM
+* The three data types — userData (cloud-config for users, packages, scripts), networkData (network-config v2), and metadata (instance identity)
+* Cloud-init runs in stages: network configuration applies first, then user/file configuration, then commands and packages
+* Two manifest patterns: inline `cloudInitNoCloud` for simple cases, Secret references for complex or sensitive data
+* Verification using `cloud-init status --long` and `/var/log/cloud-init.log`
+
+== See Also
+
+* xref:networking:static-ip-configuration.adoc[] - Deep-dive into static IP, DHCP, multiple interfaces, and VLANs with cloud-init
+* xref:networking:cloud-init-troubleshooting.adoc[] - Diagnostic procedures and solutions for cloud-init issues
+* xref:vm-configuration:remote-access-windows-vms.adoc[] - Windows VM configuration with Sysprep
+* link:https://cloudinit.readthedocs.io/en/latest/[Cloud-init Official Documentation,window=_blank]
+* link:https://cloudinit.readthedocs.io/en/latest/reference/modules.html[Cloud-init Module Reference,window=_blank]
+* link:https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#cloudinitnocloud[KubeVirt cloudInitNoCloud Documentation,window=_blank]

--- a/modules/getting-started/pages/index.adoc
+++ b/modules/getting-started/pages/index.adoc
@@ -12,6 +12,7 @@ In this section, you will learn:
 * Prerequisites and required tools for working with OpenShift Virtualization
 * Basic usage of the virtctl command-line tool for managing virtual machines
 * How to configure default storage for virtual machine deployments
+* Cloud-init fundamentals and VM initialization patterns
 
 == Prerequisites
 
@@ -42,9 +43,13 @@ Create virtual machines from the OpenShift web console using templates.
 xref:vm-lifecycle-states.adoc[]::
 Understand VM lifecycle states and basic operations for effective VM management.
 
+xref:cloud-init-fundamentals.adoc[]::
+Learn cloud-init fundamentals, execution stages, common modules, and how to embed cloud-init configuration in VirtualMachine manifests.
+
 == Next Steps
 
 After completing this module, you'll be ready to explore:
 
 * xref:storage:index.adoc[Storage Configuration] - Deep dive into storage options
 * xref:networking:index.adoc[Networking Configuration] - Network setup for VMs
+* xref:networking:cloud-init-troubleshooting.adoc[Cloud-init Troubleshooting] - Diagnostic procedures for cloud-init issues


### PR DESCRIPTION
## Description

Adds a foundational cloud-init tutorial to the getting-started module that introduces what cloud-init is, how KubeVirt delivers it via the NoCloud datasource, the three data types (userData, networkData, metadata), execution stages, common cloud-config modules, and two manifest embedding patterns (inline vs Secret reference). This becomes the canonical reference for cloud-init basics that other tutorials can xref back to.

## Type of Change

- [x] New tutorial/content
- [ ] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [x] Manifest/example addition

## Related Issue

Resolves #205

## Content Checklist

### Technical Accuracy
- [x] All commands have been tested on a live cluster
- [x] YAML manifests are complete and valid (not partial snippets)
- [x] Technical details verified against official documentation
- [x] Use Professional language

### Testing & Verification
- [x] Verified on OpenShift version: 4.18+
- [x] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [x] AsciiDoc syntax is correct
- [x] Code blocks specify language (e.g., `[source,yaml]`)
- [x] All internal links (xrefs) are working
- [x] All external links use `window=_blank`
- [x] Navigation (`nav.adoc`) updated if adding new pages
- [x] Home page updated if adding new module/tutorial

### Build & Preview
- [x] `npm run build` completes without errors
- [x] Local preview verified (`npm run serve`)
- [x] No broken xref warnings in build output
- [x] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made

- Added `modules/getting-started/pages/cloud-init-fundamentals.adoc` — ~500 line tutorial covering cloud-init concepts, KubeVirt NoCloud delivery, data types, execution stages, common modules (users, packages, runcmd, write_files), inline vs Secret embedding patterns, verification, and common mistakes
- Added `modules/getting-started/attachments/minimal-cloud-init-vm.yaml` — VirtualMachine with inline cloudInitNoCloud using `user:` object + `users:` list pattern
- Added `modules/getting-started/attachments/cloud-init-secret-vm.yaml` — Secret + VirtualMachine using `secretRef` pattern
- Updated `modules/getting-started/nav.adoc` — added cloud-init-fundamentals entry
- Updated `modules/getting-started/pages/index.adoc` — added to What You'll Learn, Sections, and Next Steps with xrefs to static-ip-configuration and cloud-init-troubleshooting

## Additional Notes

- Uses current cloud-init best practices: `user:` object with `lock_passwd`/`plain_text_passwd` instead of the deprecated `user` string (deprecated in 22.2, scheduled for removal in 27.2), `ssh_pwauth: true`, and `secretRef` instead of `userDataSecretRef`
- Network config v2 section includes static IP, DNS, routes, and MAC-based matching examples; defers to `networking:static-ip-configuration.adoc` for multi-interface/VLAN deep-dives
- Sysprep for Windows VMs is briefly mentioned with xref to remote-access-windows-vms