### PR TITLE
Update README and add standard project files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers via the repository issue tracker or by contacting the repository owner directly.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,20 +23,28 @@ make check-deps
 
 ## Quick Start
 
-1. **Clone the repository:**
+1. **Fork the repository** on GitHub by clicking the **Fork** button on https://github.com/RedHatQuickCourses/ocp-virt-cookbook.
+
+2. **Clone your fork:**
 
    ```bash
-   git clone https://github.com/RedHatQuickCourses/ocp-virt-cookbook.git
+   git clone https://github.com/<your-username>/ocp-virt-cookbook.git
    cd ocp-virt-cookbook
    ```
 
-2. **Install dependencies:**
+3. **Add the upstream remote:**
+
+   ```bash
+   git remote add upstream https://github.com/RedHatQuickCourses/ocp-virt-cookbook.git
+   ```
+
+4. **Install dependencies:**
 
    ```bash
    make setup
    ```
 
-3. **Start development environment:**
+5. **Start development environment:**
 
    ```bash
    make dev
@@ -48,16 +56,11 @@ make check-deps
 
 ### Creating a New Tutorial
 
-1. **Create a feature branch:**
+1. **Sync your fork and create a feature branch:**
 
    ```bash
-   make branch NAME=add-tutorial-xyz
-   ```
-
-   Or manually:
-
-   ```bash
-   git checkout -b yourusername/add-tutorial-xyz
+   git fetch upstream
+   git checkout -b yourusername/add-tutorial-xyz upstream/main
    ```
 
 2. **Add your tutorial:**
@@ -82,7 +85,7 @@ make check-deps
 
    This runs all checks: linting, building, link validation, and documentation review.
 
-5. **Commit and push:**
+5. **Commit and push to your fork:**
 
    ```bash
    git add modules/
@@ -90,13 +93,11 @@ make check-deps
    git push -u origin yourusername/add-tutorial-xyz
    ```
 
-6. **Create a pull request:**
+6. **Create a pull request** from your fork's branch to the upstream `main` branch using the GitHub web UI or:
 
    ```bash
-   make pr
+   gh pr create --repo RedHatQuickCourses/ocp-virt-cookbook
    ```
-
-   Or use the GitHub web UI.
 
 ## Make Targets Reference
 

--- a/README.md
+++ b/README.md
@@ -1,128 +1,86 @@
 # OpenShift Virtualization Cookbook
 
-This cookbook provides bite-sized, practical tutorials for deploying and managing virtualization workloads on Red Hat OpenShift Virtualization. It serves as a complement to official OpenShift Virtualization training and documentation, offering hands-on guides with tested workflows, YAML manifests, and troubleshooting tips specifically designed for partner and customer engineers getting started with OpenShift Virtualization.
+[![Build](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/actions/workflows/build.yml/badge.svg)](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/actions/workflows/build.yml)
+[![OpenShift 4.18+](https://img.shields.io/badge/OpenShift-4.18%2B-ee0000)](https://docs.redhat.com/en/documentation/openshift_container_platform/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-## Quick Start (Contributors)
+Bite-sized, practical tutorials for deploying and managing virtualization workloads on Red Hat OpenShift Virtualization. This cookbook complements official training and documentation with hands-on guides, tested YAML manifests, and troubleshooting tips for partner and customer engineers.
 
-Get started contributing in minutes:
+**[Browse the live documentation](https://redhatquickcourses.github.io/ocp-virt-cookbook)**
+
+## Content Overview
+
+| Module | Topics |
+|--------|--------|
+| [Getting Started](https://redhatquickcourses.github.io/ocp-virt-cookbook/ocp-virt-cookbook/1/getting-started/index.html) | Prerequisites, operator installation, creating VMs, virtctl CLI, VM lifecycle states, default storage class |
+| [Storage](https://redhatquickcourses.github.io/ocp-virt-cookbook/ocp-virt-cookbook/1/storage/index.html) | LVM Operator, storage classes, HostPath provisioner, multi-disk configuration, troubleshooting |
+| [Networking](https://redhatquickcourses.github.io/ocp-virt-cookbook/ocp-virt-cookbook/1/networking/index.html) | UDN primary networks, localnet, VLAN, Linux bridges, SR-IOV, static IPs, ingress routes, troubleshooting |
+| [VM Configuration](https://redhatquickcourses.github.io/ocp-virt-cookbook/ocp-virt-cookbook/1/vm-configuration/index.html) | Templates, node placement, hotplug volumes/interfaces, remote access (Linux/Windows), internal DNS, VirtIO drivers |
+| [Performance](https://redhatquickcourses.github.io/ocp-virt-cookbook/ocp-virt-cookbook/1/performance/index.html) | CPU pinning, NUMA/hugepages, real-time VMs, resource limits and QoS |
+| [VM Lifecycle](https://redhatquickcourses.github.io/ocp-virt-cookbook/ocp-virt-cookbook/1/vm-lifecycle/index.html) | Golden images, boot order/sources, snapshots, cloning, qcow2 import |
+| [API](https://redhatquickcourses.github.io/ocp-virt-cookbook/ocp-virt-cookbook/1/api/index.html) | Component overview |
+| [Appendix](https://redhatquickcourses.github.io/ocp-virt-cookbook/ocp-virt-cookbook/1/appendix/glossary.html) | Glossary and reference material |
+
+## Prerequisites for Tutorial Users
+
+To follow the tutorials you need:
+
+- An OpenShift 4.18+ cluster with the OpenShift Virtualization operator installed
+- The `oc` CLI authenticated to the cluster
+- The `virtctl` CLI ([installation guide](https://redhatquickcourses.github.io/ocp-virt-cookbook/ocp-virt-cookbook/1/getting-started/virtctl-basics.html))
+- Basic familiarity with Kubernetes concepts (pods, namespaces, services)
+
+Some tutorials have additional requirements (specific storage backends, network configurations, or multiple nodes). Each tutorial lists its own prerequisites at the top.
+
+## Compatibility
+
+| Component | Version |
+|-----------|---------|
+| OpenShift Container Platform | 4.18+ |
+| OpenShift Virtualization Operator | 4.18+ |
+| KubeVirt | Bundled with OCP Virt operator |
+| `oc` CLI | Matching cluster version |
+| `virtctl` CLI | Matching operator version |
+
+## Quick Start for Contributors
 
 ```bash
 make setup         # Install all dependencies
-make dev           # Start local preview
+make dev           # Start local preview at http://localhost:8080
 ```
 
-Make your changes, then:
+Make your changes, then validate and submit:
 
 ```bash
-make validate      # Run all checks
+make validate      # Run all checks (lint, build, links, review)
 make pr            # Push and create PR
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide, including AsciiDoc conventions, testing, and the PR process.
 
-## Creating Course Content
+## Related Resources
 
-We use a system called Antora (https://antora.org) to publish courses. Antora expects the files and folders in a source repository to be arranged in a certain opinionated way to simplify the process of writing course content using asciidoc, and then converting the asciidoc source to HTML.
+- [OpenShift Virtualization Documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/virtualization/index)
+- [KubeVirt User Guide](https://kubevirt.io/user-guide/)
+- [Antora Documentation](https://docs.antora.org/)
+- [AsciiDoc Language Reference](https://docs.asciidoctor.org/asciidoc/latest/)
 
-Refer to the quick courses contributor guide for a detailed guide on how to work with Antora tooling and publish courses.
+## Roadmap
 
-## TL;DR Quickstart
-
-This section is intended as a quick start guide for technically experienced members. The contributor guide remains the canonical reference for the course content creation process with detailed explanations, commands, video demonstrations, and screenshots.
-
-### Pre-requisites
-
-- You have a macOS or Linux workstation. Windows has not been tested, or supported. You can try using a WSL2 based environment to run these steps - YMMV!
-- You have a somewhat recent version of the Git client installed on your workstation
-- You have a somewhat new Node.js LTS release (Node.js 16+) installed locally.
-- You have [pnpm](https://pnpm.io/installation); npm will work but not recommended
-- Install a recent version of Visual Studio Code. Other editors with asciidoc editing support may work - YMMV, and you are on your own...
-
-### Antora Files and Folder Structure
-
-The _antora.yml_ file lists the chapters/modules/units that make up the course.
-
-Each chapter entry points to a _nav.adoc_ file that lists the sections in that chapter. The home page of the course is rendered from _modules/ROOT/pages/index.adoc_.
-
-Each chapter lives in a separate folder under the _modules_ directory. All asciidoc source files live under the _modules/CHAPTER/pages_ folder.
-
-To create a new chapter in the course, create a new folder under _modules_.
-
-To add a new section under a chapter create an entry in the _modules/CHAPTER/nav.adoc_ file and then create the asciidoc file in the _modules/CHAPTER/pages_ folder.
-
-### Steps
-
-1. Clone or fork the course repository.
-
-```
-$ git clone git@github.com:RedHatQuickCourses/ocp-virt-cookbook.git
-```
-
-2. Install the pnpm dependencies for the course tooling.
-
-```
-$ cd ocp-virt-cookbook
-$ pnpm install
-```
-
-3. Start the asciidoc to HTML compiler in the background. This command watches for changes to the asciidoc source content in the **modules** folder and automatically re-generates the HTML content.
-
-```
-$ pnpm run watch:adoc
-```
-
-4. Start a local web server to serve the generated HTML files. Navigate to the URL printed by this command to preview the generated HTML content in a web browser.
-
-```
-$ pnpm run serve
-```
-
-5. Before you make any content changes, create a local Git branch based on the **main** branch. As a good practice, prefix the branch name with your GitHub ID. Use a suitable branch naming scheme that reflects the content you are creating or changing.
-
-```
-$ git checkout -b username/add-tutorial-xyz
-```
-
-6. Make your changes to the asciidoc files. Preview the generated HTML and verify that there are no rendering errors. Commit your changes to the local Git branch and push the branch to GitHub.
-
-```
-$ git add .
-$ git commit -m "Add tutorial for XYZ feature"
-$ git push -u origin username/add-tutorial-xyz
-```
-
-7. Create a GitHub pull request (PR) for your changes using the GitHub web UI. For forks, create a PR that merges your forked changes into the `main` branch of this repository.
-8. Request a review of the PR from your technical peers and/or a member of the PTL team.
-9. Make any changes requested by the reviewer in the **same** branch as the PR, and then commit and push your changes to GitHub. If other team members have made changes to the PR, then do not forget to do a **git pull** before committing your changes.
-10. Once reviewer(s) approve your PR, you should merge it into the **main** branch.
-11. Wait for a few minutes while the automated GitHub action publishes your changes to the production GitHub pages website.
-12. Verify that your changes have been published to the production GitHub pages website at https://redhatquickcourses.github.io/ocp-virt-cookbook
-
-## Current Roadmap
-
-The project roadmap covers 105 open issues organized across four quarters, prioritized by dependency order, module cohesion, and effort level. Contributions are welcome -- feel free to open new issues for topics you'd like to see covered, or comment on any existing open issue to request that it be prioritized.
-
-| Quarter | Theme | Issues | Effort Profile |
-|---|---|---|---|
-| **Q2 2026** | Foundation, Quick Wins, Tech Debt | 17 | Small items, fast turnaround |
-| **Q3 2026** | Core Networking and Storage | 27 | Mix of improvements and standard tutorials |
-| **Q4 2026** | VM Ops, Migration, Monitoring | 28 | Intermediate tutorials and operations |
-| **Q1 2027** | Deep Dives and Advanced | 33 | Large, reference-grade content |
-
-**Q2 2026** clears the oldest backlog items, adds CI infrastructure, polishes the Getting Started module with diagrams and quick-start tutorials, and resolves long-standing housekeeping issues.
-
-**Q3 2026** fills out the two most critical technical modules -- networking and storage -- with 15 topology diagram improvements for existing pages plus 14 new tutorials covering network policies, dual-stack, MetalLB, ODF/Ceph, NFS, CDI operations, and more.
-
-**Q4 2026** delivers the operational layer: VMware migration with MTV, live migration, monitoring and metrics, GPU configuration, Ansible automation, RBAC and multi-tenancy, plus diagram improvements across the VM configuration, lifecycle, and performance modules.
-
-**Q1 2027** caps the roadmap with 33 deep dives and advanced tutorials -- comprehensive reference guides on topics like virtctl CLI, cloud-init, UDN architecture, storage class selection, HCP, CIS benchmarks, and managed cloud services (ROSA/ARO).
-
-See [docs/ROADMAP.md](docs/ROADMAP.md) for the full detailed roadmap with every issue mapped to its quarter.
+Contributions are welcome -- open new issues for topics you'd like to see, or comment on existing issues to request prioritization. See [docs/ROADMAP.md](docs/ROADMAP.md) for quarterly themes, design principles, and how to view the live project board.
 
 ## Problems and Feedback
 
-If you run into any issues, report bugs/suggestions/improvements about this course here - https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues
+Report bugs, suggestions, or improvements at https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for reporting security vulnerabilities.
+
+## Code of Conduct
+
+See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community standards.
 
 ## License
 
-This project is licensed under the MIT License - see the LICENSE file for details.
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, send a report to the project maintainers by emailing the repository owner or using [GitHub's private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) feature on this repository.
+
+Include the following in your report:
+
+- Description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact
+- Suggested fix (if any)
+
+## Response Timeline
+
+- **Acknowledgment**: Within 5 business days of receipt
+- **Assessment**: Within 10 business days
+- **Resolution**: Depends on severity and complexity
+
+## Scope
+
+This project is a documentation site built with Antora. Security concerns most likely involve:
+
+- Credentials or secrets accidentally committed to the repository
+- Insecure commands or configurations recommended in tutorials
+- Vulnerable dependencies in the build toolchain
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| main branch (latest) | Yes |
+| Older branches | No |
+
+## Best Practices for Contributors
+
+- Never commit secrets, tokens, passwords, or credentials
+- Use placeholder values (e.g., `<your-token>`) in tutorials that require credentials
+- Do not include kubeconfig files, `.env` files, or private keys
+- Review the [CONTRIBUTING.md](CONTRIBUTING.md) guide for content standards

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,262 +1,31 @@
-# OpenShift Virtualization Cookbook -- Current Roadmap
+# OpenShift Virtualization Cookbook -- Roadmap
 
-> Covers 105 open, unassigned issues spread across four quarters from Q2 2026 through Q1 2027.
+The live roadmap is maintained on the [GitHub Project board](https://github.com/users/acmenezes/projects/3/views/4?sortedBy%5Bdirection%5D=asc&sortedBy%5BcolumnId%5D=355569932).
 
-Contributions are welcome -- feel free to open new issues for topics you'd like to see covered, or comment on any existing open issue to request that it be prioritized.
+### Viewing the Roadmap Timeline
+
+To see all issues as bars on the Roadmap view:
+
+1. Open the **Roadmap** view on the project board.
+2. Click the **Date fields** button (calendar icon, top right).
+3. Set both **Start date** and **Target date** to the `Quarter` iteration field.
+4. Zoom out to **Year** view to see all four quarters at once.
+
+To see the full issue list sorted by quarter, use the **Table** view and sort by the `Quarter` column.
+
+## Quarterly Themes
+
+| Quarter | Theme |
+|---------|-------|
+| **Q2 2026** | Foundation, Quick Wins, Tech Debt |
+| **Q3 2026** | Core Networking and Storage |
+| **Q4 2026** | VM Ops, Migration, Monitoring |
+| **Q1 2027** | Deep Dives and Advanced |
 
 ## Design Principles
 
-1. **Oldest first** -- Issues open since January-March 2026 get priority in the earliest quarter that matches their topic area.
-2. **Dependencies flow downhill** -- Getting Started content must exist before Deep Dives can reference it as a prerequisite. Networking and storage tutorials must exist before migration and operations tutorials can link to them.
-3. **Quick wins build momentum** -- The 32 "good first issue" improvements are spread across Q2-Q4, making each quarter productive from day one.
-4. **Deep dives are last by design** -- They are the most expensive to write (5000+ words, extensive testing), benefit from all standard tutorials existing first, and by then CI and style conventions will be fully battle-tested.
+1. **Oldest first** -- Issues open since early 2026 get priority in the earliest quarter that matches their topic area.
+2. **Dependencies flow downhill** -- Getting Started content must exist before Deep Dives can reference it as a prerequisite.
+3. **Quick wins build momentum** -- Small improvements are spread across quarters, making each one productive from day one.
+4. **Deep dives are last by design** -- They are the most expensive to write, benefit from all standard tutorials existing first, and by then CI and style conventions will be fully battle-tested.
 5. **Module cohesion** -- Issues in the same module are grouped in the same quarter so contributors can batch-produce similar work efficiently.
-
-## Summary
-
-| Quarter | Theme | Issues | Effort Profile |
-|---|---|---|---|
-| **Q2 2026** | Foundation, Quick Wins, Tech Debt | 17 | Small items, fast turnaround |
-| **Q3 2026** | Core Networking and Storage | 27 | Mix of improvements and standard tutorials |
-| **Q4 2026** | VM Ops, Migration, Monitoring | 28 | Intermediate tutorials and operations |
-| **Q1 2027** | Deep Dives and Advanced | 33 | Large, reference-grade content |
-
----
-
-## Q2 2026 (Current Quarter: May -- June)
-
-**Theme: Foundation, Quick Wins, and Technical Debt**
-
-Clear the backlog of oldest issues, do the housekeeping that unblocks everything else, and knock out the "good first issue" improvements that polish existing content quickly. These improvements also serve as templates for future contributors.
-
-### Housekeeping and Infrastructure (5 issues)
-
-| # | Title | Rationale |
-|---|---|---|
-| [75](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/75) | Update README and add standard project files | Oldest good-first-issue; makes the project welcoming |
-| [83](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/83) | Add CI pipeline with GitHub Actions for tutorial tests | Enables automated quality gates for all future work |
-| [146](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/146) | Project-wide formatting and style cleanup from CI review linter | Clean slate before adding 90+ new pages |
-| [141](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/141) | Real-Time VMs tutorial: add guest RT kernel image variant | Fix to existing content, quick patch |
-| [20](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/20) | [Feature]: How to connect to Windows VM via SSH | Old issue, small scope, complements existing Windows tutorial |
-
-### Getting Started Improvements (5 issues)
-
-| # | Title |
-|---|---|
-| [210](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/210) | Add learning path diagram to Getting Started index |
-| [209](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/209) | Add state machine diagram to VM Lifecycle States tutorial |
-| [208](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/208) | Add resource flow diagram to Create VM from Web Console tutorial |
-| [207](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/207) | Add architecture diagram to Install OpenShift Virtualization tutorial |
-| [206](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/206) | Tutorial: OpenShift Virtualization Architecture Overview |
-
-### Getting Started Tutorials (4 issues)
-
-| # | Title |
-|---|---|
-| [202](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/202) | Quick Start: Your First VM in 5 Minutes |
-| [203](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/203) | Creating a VM from CLI Using YAML Manifests |
-| [204](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/204) | Installing and Configuring the QEMU Guest Agent |
-| [205](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/205) | Cloud-init Fundamentals for OpenShift Virtualization VMs |
-
-### Oldest Pending Tutorials (3 issues)
-
-| # | Title |
-|---|---|
-| [11](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/11) | Storage Profiles for OpenShift Virtualization |
-| [46](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/46) | Deploying Windows VMs with VirtIO Drivers |
-| [86](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/86) | Transferring files to and from VMs |
-
-**Q2 Total: 17 issues**
-
----
-
-## Q3 2026 (July -- September)
-
-**Theme: Core Networking and Storage Content**
-
-With the foundation polished in Q2, the project fills out its two most critical technical modules: networking and storage. These are the topics users ask about most when adopting OpenShift Virtualization. The improvement issues add diagrams to existing pages (low effort), while the new tutorials fill major content gaps.
-
-### Networking Improvements (8 issues)
-
-| # | Title |
-|---|---|
-| [177](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/177) | Add master topology decision diagram to networking index |
-| [178](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/178) | Add topology diagram to UDN Primary Networks tutorial |
-| [179](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/179) | Add topology diagram to Localnet Secondary (CUDN) tutorial |
-| [180](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/180) | Add topology diagram to Localnet VLAN (NAD) tutorial |
-| [181](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/181) | Add topology diagram to Localnet VLAN (CUDN) tutorial |
-| [182](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/182) | Add topology diagram to Layer 2 Secondary Networks tutorial |
-| [183](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/183) | Add topology diagram to Linux Bridges tutorial |
-| [184](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/184) | Add topology diagram to VM Ingress Routes tutorial |
-
-### New Networking Tutorials (7 issues)
-
-| # | Title |
-|---|---|
-| [171](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/171) | Network Policies for Virtual Machines |
-| [172](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/172) | Dual-Stack IPv4/IPv6 Networking for VMs |
-| [173](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/173) | Network Interface Hotplugging for Running VMs |
-| [174](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/174) | VM-to-VM and VM-to-Pod Communication Patterns |
-| [175](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/175) | Network Mapping for VMware-to-OpenShift Migration |
-| [176](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/176) | MetalLB and Load Balancer Services for VM Workloads |
-| [215](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/215) | Network Performance Tuning for Virtual Machines |
-
-### Storage Improvements (5 issues)
-
-| # | Title |
-|---|---|
-| [196](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/196) | Add storage decision diagram to storage index page |
-| [197](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/197) | Add architecture diagram to LVM Operator tutorial |
-| [198](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/198) | Add architecture diagram to HostPath Provisioner tutorial |
-| [199](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/199) | Add storage tiering diagram to Multi-Disk VM Configuration tutorial |
-| [200](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/200) | Add provisioning flow diagram to Storage Classes tutorial |
-
-### New Storage Tutorials (7 issues)
-
-| # | Title |
-|---|---|
-| [190](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/190) | ODF/Ceph Storage for Virtual Machines |
-| [191](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/191) | NFS Storage for Virtual Machine Workloads |
-| [192](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/192) | Expanding VM Disk Size (PVC Volume Expansion) |
-| [193](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/193) | VM Disk I/O Performance Tuning |
-| [194](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/194) | CDI Operations: DataVolumes, Imports, and Upload |
-| [195](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/195) | Storage Requirements for VM Live Migration |
-| [201](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/201) | Thin vs Thick Provisioning for VM Disks |
-
-**Q3 Total: 27 issues**
-
----
-
-## Q4 2026 (October -- December)
-
-**Theme: VM Configuration, Lifecycle, Migration, and Operations**
-
-With networking and storage complete, the focus shifts to operational topics that production users need: VM lifecycle management, scheduling, migration, monitoring, and the remaining intermediate-level tutorials from the original backlog. This quarter also delivers the VMware migration path -- a high-demand topic.
-
-### VM Configuration and Lifecycle Improvements (9 issues)
-
-| # | Title |
-|---|---|
-| [216](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/216) | Add topology diagram to Internal DNS for VMs tutorial |
-| [217](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/217) | Add access method decision diagram to Remote Access Linux VMs tutorial |
-| [218](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/218) | Add network topology diagram to Remote Access Windows VMs tutorial |
-| [219](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/219) | Add cluster topology diagram to Node Placement and Affinity tutorial |
-| [220](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/220) | Add before/after diagram to Hotplug Volumes and Interfaces tutorial |
-| [224](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/224) | Add import method flow diagram to Import qcow2 tutorial |
-| [225](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/225) | Add pipeline diagram to Custom Golden Images tutorial |
-| [226](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/226) | Add cloning method comparison diagram to Cloning VMs tutorial |
-| [227](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/227) | Add snapshot timeline diagram to VM Snapshots tutorial |
-
-### Performance Improvements (5 issues)
-
-| # | Title |
-|---|---|
-| [232](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/232) | Add QoS tier diagram to Resource Limits and QoS tutorial |
-| [233](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/233) | Add core assignment diagram to CPU Pinning tutorial |
-| [234](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/234) | Add NUMA topology diagram to NUMA and Hugepages tutorial |
-| [235](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/235) | Add latency stack diagram to Real-Time VMs tutorial |
-| [236](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/236) | Add progression diagram to Performance module index |
-
-### Intermediate Tutorials from Original Backlog (5 issues)
-
-| # | Title |
-|---|---|
-| [50](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/50) | Live Migration of VMs Between Cluster Nodes |
-| [51](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/51) | Migrating VMs from VMware vSphere Using MTV |
-| [56](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/56) | VM Monitoring and Metrics |
-| [58](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/58) | VM Scheduling with Tolerations and Taints |
-| [14](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/14) | GPU Configuration for Virtual Machines |
-
-### Operations and Automation Tutorials (6 issues)
-
-| # | Title |
-|---|---|
-| [157](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/157) | Day-0 IaC: Provisioning OpenShift Virtualization with Ansible |
-| [158](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/158) | Automating Post-Migration Validation with Ansible |
-| [159](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/159) | Zero-Downtime Cluster Upgrades Using Live Migration |
-| [162](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/162) | Multi-Tenancy and RBAC for VM Workloads |
-| [165](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/165) | Building a VM Self-Service Portal with Templates |
-| [166](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/166) | Resource Quotas and Chargeback for VM Workloads |
-
-### Additional Operations Content (3 issues)
-
-| # | Title |
-|---|---|
-| [10](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/10) | SR-IOV Secondary Network Configuration for VMs |
-| [163](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/163) | Comparative Benchmarking vs Legacy Hypervisors |
-| [170](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/170) | Rolling Hardware Refresh Strategy |
-
-**Q4 Total: 28 issues**
-
----
-
-## Q1 2027 (January -- March)
-
-**Theme: Deep Dives, Advanced Topics, and Strategic Content**
-
-Deep dives are the most complex content (3000-5000+ words, reference-grade). They require the standard tutorials to exist first so readers have prerequisites, and many of these topics are Advanced-labeled or target niche enterprise audiences. By this point the project's style, structure, and CI pipeline are fully mature.
-
-### Deep Dives -- Getting Started and Configuration (5 issues)
-
-| # | Title |
-|---|---|
-| [211](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/211) | Comprehensive virtctl CLI Reference |
-| [212](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/212) | OpenShift Virtualization Installation, Configuration, and Day-2 Ops |
-| [213](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/213) | VM Lifecycle Management and Automation |
-| [214](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/214) | Cloud-init for OpenShift Virtualization |
-| [221](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/221) | Secure VM Access Architecture |
-
-### Deep Dives -- VM Lifecycle and Scheduling (6 issues)
-
-| # | Title |
-|---|---|
-| [222](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/222) | Advanced VM Scheduling and Placement |
-| [223](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/223) | VM Template Governance and Self-Service Catalog |
-| [228](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/228) | Automated Golden Image Pipeline |
-| [229](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/229) | VM Snapshot Strategies and Backup Architecture |
-| [230](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/230) | Advanced Boot Configuration and PXE Automation |
-| [231](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/231) | VM Export, Import, and Cross-Cluster Mobility |
-
-### Deep Dives -- Networking (5 issues)
-
-| # | Title |
-|---|---|
-| [185](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/185) | User Defined Networks (UDN) for OpenShift Virtualization |
-| [186](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/186) | Localnet Networking Architecture |
-| [187](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/187) | Linux Bridge Networking |
-| [188](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/188) | Exposing VM Services Externally |
-| [189](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/189) | IP Address Management for VM Fleets at Scale |
-
-### Deep Dives -- Storage and Performance (5 issues)
-
-| # | Title |
-|---|---|
-| [153](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/153) | Choosing the Right Storage Class for VM Disks |
-| [154](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/154) | Vendor-Specific Storage Optimization (NetApp, Dell, Pure) |
-| [155](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/155) | Windows VM Performance Optimization |
-| [164](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/164) | Memory Overcommit for VM Density |
-| [151](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/151) | Bare Metal Deployment for Maximum VM Performance |
-
-### Deep Dives -- Platform and Advanced (5 issues)
-
-| # | Title |
-|---|---|
-| [152](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/152) | OpenShift Virtualization with Hosted Control Planes (HCP) |
-| [237](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/237) | Advanced CPU Topology and Pinning Strategies |
-| [238](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/238) | Production Real-Time VM Deployment and Validation |
-| [239](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/239) | NUMA Architecture and Memory Performance |
-| [160](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/160) | Advanced VM Observability with Prometheus and Grafana |
-
-### Advanced Tutorials (7 issues)
-
-| # | Title |
-|---|---|
-| [64](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/64) | Custom HyperConverged Configuration Options |
-| [65](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/65) | Enabling Nested Virtualization for Development and Testing |
-| [156](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/156) | Enabling Virtualization-Based Security (VBS) for Windows VMs |
-| [161](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/161) | Applying CIS Benchmarks to the OpenShift Virtualization Stack |
-| [167](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/167) | vGPU Sharing for High-Density Graphics Workloads |
-| [168](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/168) | Running OpenShift Virtualization on Managed Cloud Services (ROSA/ARO) |
-| [169](https://github.com/RedHatQuickCourses/ocp-virt-cookbook/issues/169) | Multicloud VM Management |
-
-**Q1 2027 Total: 33 issues**


### PR DESCRIPTION
- Restructure README with status badges, content overview table, prerequisites, and compatibility matrix
- Fix CONTRIBUTING.md to use fork-first workflow instead of direct clone
- Replace static ROADMAP.md with link to live GitHub Project board
- Add SECURITY.md with vulnerability reporting policy
- Add CODE_OF_CONDUCT.md based on Contributor Covenant 2.1

Closes #75