### PR TITLE
Add guest RT kernel section to Real-Time VMs tutorial

### DIFF
--- a/modules/performance/attachments/realtime-vms/vm-realtime.yaml
+++ b/modules/performance/attachments/realtime-vms/vm-realtime.yaml
@@ -55,12 +55,26 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - name: rootdisk
-        containerDisk:
-          image: quay.io/containerdisks/fedora:latest
+        dataVolume:
+          name: vm-realtime
       - name: cloudinitdisk
         cloudInitNoCloud:
           userData: |
             #cloud-config
+            user: fedora
             password: redhat
             chpasswd:
               expire: false
+            ssh_pwauth: true
+  dataVolumeTemplates:
+  - metadata:
+      name: vm-realtime
+    spec:
+      sourceRef:
+        kind: DataSource
+        name: fedora
+        namespace: openshift-virtualization-os-images
+      storage:
+        resources:
+          requests:
+            storage: 30Gi

--- a/modules/performance/pages/realtime-vms.adoc
+++ b/modules/performance/pages/realtime-vms.adoc
@@ -311,7 +311,7 @@ oc create namespace realtime-demo
 
 == Step 5: Deploy a Real-Time VM
 
-The following VM manifest combines all real-time tuning layers. It uses a standard Fedora container disk. While a purpose-built RT guest image with a real-time kernel provides the best results, the standard image is sufficient to demonstrate and verify the host-side configuration.
+The following VM manifest combines all real-time tuning layers. It uses a Fedora DataSource as the boot volume with persistent storage, which allows kernel upgrades and configuration changes to survive VM restarts. While a purpose-built RT guest image with a real-time kernel provides the best results, the standard image is sufficient to demonstrate and verify the host-side configuration.
 
 Key configuration fields:
 
@@ -389,19 +389,40 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - name: rootdisk
-        containerDisk:
-          image: quay.io/containerdisks/fedora:latest
+        dataVolume:
+          name: vm-realtime
       - name: cloudinitdisk
         cloudInitNoCloud:
           userData: |
             #cloud-config
+            user: fedora
             password: redhat
             chpasswd:
               expire: false
+            ssh_pwauth: true
+  dataVolumeTemplates:
+  - metadata:
+      name: vm-realtime
+    spec:
+      sourceRef:
+        kind: DataSource
+        name: fedora
+        namespace: openshift-virtualization-os-images
+      storage:
+        resources:
+          requests:
+            storage: 30Gi
 EOF
 ----
 
-Wait for the VM to reach Running status:
+The DataVolume clones the Fedora image from the cluster's DataSource into a persistent disk. Monitor the provisioning progress:
+
+[source,bash,role=execute]
+----
+oc get dv vm-realtime -n realtime-demo -w
+----
+
+Wait until the DataVolume shows `Succeeded`, then check the VM status:
 
 [source,bash,role=execute]
 ----
@@ -411,8 +432,8 @@ oc get vm vm-realtime -n realtime-demo -w
 Expected output:
 
 ----
-NAME          AGE   STATUS    READY
-vm-realtime   90s   Running   True
+NAME          AGE    STATUS    READY
+vm-realtime   5m     Running   True
 ----
 
 NOTE: The VM is scheduled only on nodes labeled `kubevirt.io/realtime` and `cpumanager=true`. KubeVirt adds these selectors automatically when `realtime` is specified in the VM spec. If the VM stays in `Scheduling` state, verify that the target node has both labels.
@@ -587,6 +608,121 @@ IMPORTANT: Latency results vary significantly based on hardware, BIOS settings, 
 
 Disconnect from the console by pressing `Ctrl+]`.
 
+== Step 9: Full-Stack Real-Time with a Guest RT Kernel
+
+The cyclictest results from Step 8 show max latencies in the hundreds to thousands of microseconds. This is because the standard Fedora kernel inside the guest uses `PREEMPT_DYNAMIC` scheduling, which cannot guarantee bounded preemption of in-kernel code paths. The host-side `SCHED_FIFO` priority and CPU isolation eliminate *external* jitter (other pods, IRQs, kernel threads stealing CPU time), but once a timer interrupt arrives at the vCPU, the *guest kernel* must still wake the sleeping cyclictest thread -- and a standard kernel may delay that wake-up while finishing a non-preemptible code section.
+
+Installing a `PREEMPT_RT` kernel inside the guest completes the real-time stack. With a guest RT kernel, virtually every kernel code path becomes preemptible, and cyclictest max latencies drop from milliseconds to the low tens of microseconds.
+
+[cols="2,3,3",options="header"]
+|===
+|Configuration |Guest kernel |Expected cyclictest max latency
+
+|Host RT only
+|Standard (`PREEMPT_DYNAMIC`)
+|Hundreds to thousands of microseconds
+
+|Full-stack RT
+|Real-time (`PREEMPT_RT`)
+|Low tens of microseconds
+|===
+
+=== Install the RT Kernel Inside the Guest
+
+Connect to the running VM:
+
+[source,bash,role=execute]
+----
+virtctl console vm-realtime -n realtime-demo
+----
+
+Log in as `fedora` with password `redhat`.
+
+Enable the Fedora Kernel Vanilla COPR repository, which provides `PREEMPT_RT` kernel packages:
+
+[source,bash,role=execute]
+----
+sudo dnf -y copr enable @kernel-vanilla/stable
+----
+
+Install the real-time kernel:
+
+[source,bash,role=execute]
+----
+sudo dnf -y install kernel-rt-core kernel-rt-modules
+----
+
+Set the RT kernel as the default boot entry:
+
+[source,bash,role=execute]
+----
+sudo grubby --set-default /boot/vmlinuz-*rt*
+----
+
+Disconnect from the console by pressing `Ctrl+]`.
+
+=== Reboot the VM
+
+Restart the VM to boot into the RT kernel:
+
+[source,bash,role=execute]
+----
+virtctl restart vm-realtime -n realtime-demo
+----
+
+Wait for the VM to return to Running status:
+
+[source,bash,role=execute]
+----
+oc get vm vm-realtime -n realtime-demo -w
+----
+
+=== Verify the Guest RT Kernel
+
+Connect to the VM console:
+
+[source,bash,role=execute]
+----
+virtctl console vm-realtime -n realtime-demo
+----
+
+Log in and verify the kernel version:
+
+[source,bash,role=execute]
+----
+uname -r
+----
+
+The output should contain `rt` in the version string, for example:
+
+----
+6.15.2-0.rc0.20250604gite53b1bae1f73.502.vanilla.fc42.x86_64+rt
+----
+
+Verify that `PREEMPT_RT` is active:
+
+[source,bash,role=execute]
+----
+uname -v
+----
+
+The output should include `PREEMPT_RT`, confirming fully preemptible kernel mode.
+
+=== Re-Run cyclictest with the RT Kernel
+
+Since the VM uses persistent storage, `realtime-tests` is still installed from Step 8. Run cyclictest with the same parameters:
+
+[source,bash,role=execute]
+----
+sudo cyclictest --mlockall --smp --priority=80 --interval=200 --distance=0 --duration=60
+----
+
+With the guest RT kernel, expect max latencies in the low tens of microseconds -- a significant improvement over the hundreds to thousands of microseconds seen with the standard kernel in Step 8.
+
+Disconnect from the console by pressing `Ctrl+]`.
+
+IMPORTANT: For production real-time workloads, build a custom disk image with the RT kernel pre-installed rather than installing it at runtime. This eliminates the post-boot kernel installation and reboot cycle, and guarantees consistent, version-locked deployments across all RT VMs.
+
 == Troubleshooting
 
 === VM fails to schedule: no realtime-capable nodes
@@ -693,7 +829,8 @@ In this tutorial you learned how to:
 * Deploy a real-time VM with the full stack of latency-reduction settings
 * Verify CPU pinning, hugepage backing, and SCHED_FIFO scheduling on the host
 * Measure and baseline latency using `cyclictest`
-* Understand the role of each configuration layer in eliminating specific sources of jitter
+* Install a guest RT kernel to achieve full-stack real-time and compare latency results
+* Understand the difference between host-only RT tuning and full-stack RT (host + guest RT kernel)
 
 == See Also
 


### PR DESCRIPTION
- Add Step 9 covering full-stack RT with a guest PREEMPT_RT kernel
- Explain host-only vs full-stack RT tuning with comparison table
- Document kernel-rt installation from Fedora Kernel Vanilla COPR repository
- Include grubby, virtctl restart, and verification steps for the RT kernel
- Update Summary with guest RT kernel learning objectives
Closes #141