### PR TITLE
fix agentic collections repo to new url

### DIFF
--- a/modules/agentic-vm-management/pages/getting-started.adoc
+++ b/modules/agentic-vm-management/pages/getting-started.adoc
@@ -55,11 +55,11 @@ Follow the Lola installation instructions in the upstream repository. After inst
 lola --version
 ----
 
-=== Clone the agentic-collections-skills Repository
+=== Clone the agentic-plugins Repository
 
 [source,bash,role=execute]
 ----
-git clone https://github.com/RHEcosystemAppEng/agentic-collections-skills.git
+git clone https://github.com/RHEcosystemAppEng/agentic-plugins.git
 ----
 
 [source,bash,role=execute]
@@ -303,7 +303,7 @@ This tutorial creates no cluster resources. No cleanup is required.
 == See Also
 
 * xref:index.adoc[Agentic VM Management Module Overview]
-* link:https://github.com/RHEcosystemAppEng/agentic-collections-skills/tree/main/rh-virt[rh-virt Skill Pack Repository,window=_blank]
+* link:https://github.com/RHEcosystemAppEng/agentic-plugins/tree/main/rh-virt[rh-virt Skill Pack Repository,window=_blank]
 * link:https://github.com/LobsterTrap/lola[Lola Skill Pack Manager,window=_blank]
 * link:https://github.com/openshift/openshift-mcp-server[OpenShift MCP Server,window=_blank]
 * link:https://modelcontextprotocol.io[Model Context Protocol Specification,window=_blank]

--- a/modules/agentic-vm-management/pages/index.adoc
+++ b/modules/agentic-vm-management/pages/index.adoc
@@ -75,7 +75,7 @@ Install the `rh-virt` skill pack, configure the MCP server, and verify end-to-en
 
 == See Also
 
-* link:https://github.com/RHEcosystemAppEng/agentic-collections-skills/tree/main/rh-virt[rh-virt Skill Pack Repository,window=_blank]
+* link:https://github.com/RHEcosystemAppEng/agentic-plugins/tree/main/rh-virt[rh-virt Skill Pack Repository,window=_blank]
 * link:https://github.com/openshift/openshift-mcp-server[OpenShift MCP Server,window=_blank]
 * link:https://docs.openshift.com/container-platform/latest/virt/about_virt/about-virt.html[OpenShift Virtualization Documentation,window=_blank]
 * link:https://modelcontextprotocol.io[Model Context Protocol Specification,window=_blank]


### PR DESCRIPTION
## Description

Agenti collection has a new home repo URL. This is just a small update.

New repo is https://github.com/RHEcosystemAppEng/agentic-plugins/tree/main/rh-virt


