### PR TITLE
Fix make setup to install pnpm and node dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GALAXY  := $(VENV)/bin/ansible-galaxy
 PYTHON  := $(VENV)/bin/python3
 BUILD_DIR := build
 NODE_MODULES := node_modules
+NODE_INSTALLED := $(NODE_MODULES)/.installed
 
 .DEFAULT_GOAL := help
 
@@ -57,7 +58,7 @@ help:
 # ── Setup ───────────────────────────────────────────────────────────
 
 .PHONY: setup
-setup: $(VENV)/bin/activate
+setup: $(VENV)/bin/activate $(NODE_INSTALLED)
 	@echo "Setup complete. Run 'source $(VENV)/bin/activate' or use make targets."
 
 $(VENV)/bin/activate:
@@ -66,6 +67,13 @@ $(VENV)/bin/activate:
 	$(PIP) install kubernetes ansible yamllint
 	$(GALAXY) collection install -r tests/requirements.yaml
 	@touch $(VENV)/bin/activate
+
+$(NODE_INSTALLED):
+	@command -v pnpm > /dev/null 2>&1 || \
+		{ echo "pnpm not found. Installing..."; \
+		  npm install -g pnpm; }
+	pnpm install
+	@touch $(NODE_INSTALLED)
 
 .PHONY: check-deps
 check-deps:


### PR DESCRIPTION
Fixes #282

## Changes

- Add `NODE_INSTALLED` variable pointing to `$(NODE_MODULES)/.installed` marker file
- Create `$(NODE_INSTALLED)` target that:
  - Checks if pnpm is installed
  - If not, installs it via `npm install -g pnpm`
  - Runs `pnpm install`
  - Creates marker file to prevent re-running unnecessarily
- Update `setup` target to depend on both `$(VENV)/bin/activate` and `$(NODE_INSTALLED)`

## Problem Solved

Previously, `make setup` only installed Python/Ansible test dependencies. Documentation build targets (`make build`, `make dev`, etc.) require pnpm, but it wasn't automatically installed. This caused `pnpm: command not found` errors on fresh clones.

## Testing

- Build passes: `pnpm run build` ✓
- Follows the same file-based marker pattern as the Python venv target
- `make clean-all` removes the marker file

## Benefits

- `make setup` now truly installs all dependencies (test + docs)
- First-time contributors can run `make setup && make dev` successfully
- Consistent with project's existing make target patterns