### PR TITLE
Fix: malformed lists in vm-lifecycle/custom-golden-images

### DIFF
--- a/modules/vm-lifecycle/pages/custom-golden-images.adoc
+++ b/modules/vm-lifecycle/pages/custom-golden-images.adoc
@@ -8,6 +8,7 @@ This tutorial demonstrates how to create custom golden images for OpenShift Virt
 == What are Golden Images?
 
 Golden images are standardized, pre-configured VM images that contain:
+
 - Base operating system
 - Pre-installed software packages
 - System configurations
@@ -15,6 +16,7 @@ Golden images are standardized, pre-configured VM images that contain:
 - Optimizations
 
 Benefits of using golden images:
+
 - Faster VM deployment (no need to install software after boot)
 - Consistency across all VMs
 - Reduced configuration errors
@@ -32,6 +34,7 @@ Benefits of using golden images:
 == Golden Image Workflow
 
 The process involves these steps:
+
 . Deploy a base VM from a standard OS image
 . Customize the VM (install software, configure settings)
 . Generalize the VM (remove machine-specific data)
@@ -568,6 +571,7 @@ oc delete namespace golden-images
 == Summary
 
 In this tutorial, you learned how to:
+
 - Deploy and customize a base VM
 - Generalize a VM for reuse as a golden image
 - Create a DataSource for the golden image


### PR DESCRIPTION
## Description

In asciidoc, lists must be preceded by a newline to be displayed correctly when it is not the first element in a block (e.g. if there is preceding paragraph text).

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [x] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

<!-- Link to the issue this PR addresses -->
None

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [ ] Technical details verified against official documentation
- [ ] Use Professional language

### Testing & Verification
- [ ] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [x] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [ ] All internal links (xrefs) are working
- [ ] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

### Build & Preview
- [x] `npm run build` completes without errors
- [x] Local preview verified (`npm run serve`)
- [x] No broken xref warnings in build output
- [ ] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made
- Added whitespace in `vm-lifecycle/custom-golden-images` as needed for ordered and unordered lists to be displayed correctly

## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

