### PR TITLE
Fix: malformed lists in vm-lifecycle/import-qcow2-boot-volume

### DIFF
--- a/modules/vm-lifecycle/pages/import-qcow2-boot-volume.adoc
+++ b/modules/vm-lifecycle/pages/import-qcow2-boot-volume.adoc
@@ -370,6 +370,7 @@ NOTE: ContainerDisks are ephemeral - changes are lost when the VM stops unless y
 This method combines VM creation with upload capability using DataVolumeTemplates. The DataVolume is defined inline within the VM spec and is created automatically when you create the VM.
 
 **When to use this method:**
+
 - You want to define the VM and its storage in a single manifest
 - You're using GitOps or declarative workflows
 - You want the DataVolume lifecycle tied to the VM
@@ -454,11 +455,13 @@ virtctl start vm-with-upload -n imported-vms
 ----
 
 **Advantages of this method:**
+
 - Single manifest defines both VM and storage
 - DataVolume lifecycle is managed with the VM
 - Good for Infrastructure-as-Code workflows
 
 **Disadvantages:**
+
 - More complex than separate PVC creation
 - Upload must happen after VM creation
 - Subject to DataVolume/virtctl compatibility issues
@@ -539,6 +542,7 @@ virtctl image-upload pvc <pvc-name> \
 ----
 
 Common causes:
+
 * **CDI operator issues**: Check that `cdi-deployment` and `cdi-operator` pods are running
 * **Storage class issues**: Verify your StorageClass can provision volumes
 
@@ -602,6 +606,7 @@ virtctl console fedora-imported-vm -n imported-vms
 ----
 
 Common issues:
+
 * Image is corrupted - verify checksum
 * Wrong machine type - adjust machine.type in VM spec
 * Missing bootloader - ensure image has proper boot configuration


### PR DESCRIPTION
## Description

In asciidoc, lists must be preceded by a newline to be displayed correctly when it is not the first element in a block (e.g. if there is preceding paragraph text).

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [x] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

<!-- Link to the issue this PR addresses -->
None

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [ ] Technical details verified against official documentation
- [ ] Use Professional language

### Testing & Verification
- [ ] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [x] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [ ] All internal links (xrefs) are working
- [ ] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

### Build & Preview
- [x] `npm run build` completes without errors
- [x] Local preview verified (`npm run serve`)
- [x] No broken xref warnings in build output
- [ ] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made
- Added whitespace in `vm-lifecycle/import-qcow2-boot-volume` as needed for ordered and unordered lists to be displayed correctly

## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

