### PR TITLE
Fix: malformed lists in vm-lifecycle/golden-images-troubleshooting

### DIFF
--- a/modules/vm-lifecycle/pages/golden-images-troubleshooting.adoc
+++ b/modules/vm-lifecycle/pages/golden-images-troubleshooting.adoc
@@ -71,6 +71,7 @@ oc get vmi base-fedora-vm -n golden-images -o yaml
 ----
 
 Look for:
+
 - `status.phase: Running`
 - `status.interfaces[].ipAddress` (VM has an IP)
 - `status.guestOSInfo.id: fedora` (Guest agent is running)
@@ -321,6 +322,7 @@ oc logs -n golden-images <importer-pod-name>
 ----
 
 **Common Causes**:
+
 - Source DataSource not available
 - Network issues downloading image
 - Insufficient storage space
@@ -369,6 +371,7 @@ oc get events -n golden-images --sort-by='.lastTimestamp' | grep -i error
 ----
 
 **Common Causes**:
+
 - DataVolume in `PendingPopulation` or failed state
 - Storage class issues
 - PVC binding issues
@@ -439,6 +442,7 @@ systemctl status nginx
 ----
 
 **Common Causes**:
+
 - Base VM was not customized before creating DataSource
 - DataSource references wrong PVC
 - VM cloning failed
@@ -530,6 +534,7 @@ oc logs -n golden-images -l app=containerized-data-importer --tail=100
 ----
 
 **Common Causes**:
+
 - Large disk size
 - Storage backend performance
 - Not using efficient cloning (e.g., not using DataSource)


### PR DESCRIPTION
## Description

In asciidoc, lists must be preceded by a newline to be displayed correctly when it is not the first element in a block (e.g. if there is preceding paragraph text).

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [x] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

<!-- Link to the issue this PR addresses -->
None

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [ ] Technical details verified against official documentation
- [ ] Use Professional language

### Testing & Verification
- [ ] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [x] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [ ] All internal links (xrefs) are working
- [ ] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

### Build & Preview
- [x] `npm run build` completes without errors
- [x] Local preview verified (`npm run serve`)
- [x] No broken xref warnings in build output
- [ ] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made
- Added whitespace in `vm-lifecycle/golden-images-troubleshooting` as needed for ordered and unordered lists to be displayed correctly

## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->
