### PR TITLE
Fix: malformed lists in vm-lifecycle/cloning-vms

### DIFF
--- a/modules/vm-lifecycle/pages/cloning-vms.adoc
+++ b/modules/vm-lifecycle/pages/cloning-vms.adoc
@@ -455,6 +455,7 @@ spec:
 *4. Remove unnecessary fields:*
 
 Remove these metadata fields that are auto-generated:
+
 * `metadata.uid`
 * `metadata.resourceVersion`
 * `metadata.creationTimestamp`
@@ -940,6 +941,7 @@ cat /etc/machine-id
 **Problem**: DataVolume shows `CloneInProgress` for extended time.
 
 **Possible causes**:
+
 * Large source volume
 * Slow storage or network
 * Host-assisted cloning on large volumes
@@ -1029,6 +1031,7 @@ Ensure `spec.source.pvc.name` and `spec.source.pvc.namespace` are correct.
 **Problem**: DataVolume succeeded but VM stuck in "Scheduling" or "Starting".
 
 **Possible causes**:
+
 * PVC not bound
 * Insufficient resources
 * Node scheduling issues


### PR DESCRIPTION
## Description

In asciidoc, lists must be preceded by a newline to be displayed correctly when it is not the first element in a block (e.g. if there is preceding paragraph text).

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [x] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

<!-- Link to the issue this PR addresses -->
None

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [ ] Technical details verified against official documentation
- [ ] Use Professional language

### Testing & Verification
- [ ] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [x] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [ ] All internal links (xrefs) are working
- [ ] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

### Build & Preview
- [x] `npm run build` completes without errors
- [x] Local preview verified (`npm run serve`)
- [x] No broken xref warnings in build output
- [ ] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made
- Added whitespace in `vm-lifecycle/cloning-vms` as needed for ordered and unordered lists to be displayed correctly

## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->
