### PR TITLE
sanitize asciidocs callout markers from generated yamls

### DIFF
--- a/tests/generate-test.py
+++ b/tests/generate-test.py
@@ -103,6 +103,13 @@ def _namespace_yamls(block: str) -> List[str]:
     return yamls
 
 
+def _remove_callout_markers(block: str) -> str:
+    """sanitize codeblocks of `<.>` or `<#>`"""
+    pattern = r'\s*(?:(?:#|//|;;|--)\s*)?(?:<(?:\d+|\.)>\s*)+$'
+    lines = block.split("\n")
+    cleaned = [re.sub(pattern, '', line) for line in lines]
+    return "\n".join(cleaned)
+
 # ── Main parser ─────────────────────────────────────────────────────
 
 
@@ -136,6 +143,7 @@ def parse_tutorial(adoc_path: str) -> Tuple[str, List[Resource]]:
             continue
 
         block = "\n".join(lines[i + 1 : block_end])
+        block = _remove_callout_markers(block)
         xref = _xref_above(lines, fence_open)
 
         # Rule 1: namespace commands (always check — may coexist with heredocs)


### PR DESCRIPTION
## Description

<!-- Provide a brief description of your changes -->
When running `make generate` the generate-test.py script creates yaml manifests from parsing codeblocks from the passed in .adoc guide. If any of these blocks contain asciidoc callouts `<.>` these are included in the generated yaml manifest. 
This change removes them before the yaml manifests get generated.
## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [x] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

<!-- Link to the issue this PR addresses -->
Closes #<!-- issue number -->

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [ ] Technical details verified against official documentation
- [ ] Use Professional language

### Testing & Verification
- [ ] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [ ] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [ ] All internal links (xrefs) are working
- [ ] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

### Build & Preview
- [ ] `npm run build` completes without errors
- [ ] Local preview verified (`npm run serve`)
- [ ] No broken xref warnings in build output
- [ ] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made

<!-- Provide a bullet-point list of changes -->

- 
- 
- 
## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

