### PR TITLE
Add cloning method comparison diagram and business use cases

### DIFF
--- a/modules/vm-lifecycle/pages/cloning-vms.adoc
+++ b/modules/vm-lifecycle/pages/cloning-vms.adoc
@@ -20,6 +20,16 @@ Key benefits of VM cloning:
 * Quick scale-out for identical workloads
 * Reduced time from deployment to production-ready state
 
+== Business Use Cases
+
+Cloning is most valuable when you need a VM that is already configured, rather than one built from scratch:
+
+* **Environment provisioning**: Clone a fully configured, production-like VM for QA testing. The result is both faster to produce and closer to production than a VM built from scratch.
+* **Scale-out testing**: Clone a web server VM ten times to simulate load across multiple identical instances.
+* **Cross-namespace deployment**: Promote a validated VM from a staging namespace to a production namespace, with RBAC controlling access to the source. See <<cloning-across-namespaces>>.
+* **Disaster recovery testing**: Clone production VMs into a DR namespace, exercise failover procedures against the clones, then delete them, with no impact on the running production VMs.
+* **Developer sandboxes**: Give each developer a clone of a reference VM that already has the required tools and configuration installed.
+
 == Cloning vs Golden Images
 
 While both approaches enable rapid VM deployment, they serve different purposes:
@@ -78,6 +88,62 @@ For automation or customization:
 * Create a new VM that references the cloned PVC
 * Allows customization during clone process
 * Useful for cross-namespace cloning
+
+=== Comparing the Cloning Paths
+
+The two methods above, together with the golden image pattern described in xref:custom-golden-images.adoc[Custom Golden Images], reach the same result through different resources:
+
+....
+Web console clone  — simplest, same namespace
+│
+└─ source VM
+   │
+   └─ Clone action in the console
+      │
+      └─ new VM, with a full copy of the source disks
+
+CLI DataVolume clone  — scriptable, works across namespaces
+│
+└─ source PVC
+   │
+   └─ DataVolume  — spec.source.pvc
+      │
+      └─ new PVC
+         │
+         └─ new VM referencing that PVC
+
+Clone from a golden image  — many VMs from one prepared image
+│
+└─ DataSource
+   │
+   └─ DataVolume  — spec.sourceRef
+      │
+      └─ new VM
+....
+
+Use this to choose between them:
+
+[cols="1,2,1,1",options="header"]
+|===
+|Method |Best for |Namespace |RBAC
+
+|Web console
+|One-off copies of a VM, done interactively
+|Same namespace
+|Not required
+
+|CLI DataVolume
+|Automation, scripted or repeated clones
+|Same or different
+|Required for cross-namespace
+
+|Golden image
+|Many VMs from one standardized, generalized image
+|Same or different
+|Required for cross-namespace
+|===
+
+IMPORTANT: All three paths produce a full, independent copy of the disk. A clone is not a snapshot and not a reference to the source, so each one consumes storage equal to the source volume. Plan capacity as the number of clones multiplied by the source volume size. See <<storage-space-requirements>>.
 
 === Storage Cloning Behavior
 
@@ -625,6 +691,7 @@ curl localhost
 # Shows custom HTML
 ----
 
+[#cloning-across-namespaces]
 == Cloning Across Namespaces
 
 Clone VMs to different namespaces for environment separation (dev, test, prod).
@@ -834,6 +901,7 @@ cdi.kubevirt.io/cloneType: snapshot  # Smart cloning
 cdi.kubevirt.io/cloneType: copy      # Host-assisted cloning
 ----
 
+[#storage-space-requirements]
 === Storage Space Requirements
 
 Each clone requires full storage allocation:
@@ -1087,6 +1155,8 @@ oc get namespace | grep vm-cloning
 In this tutorial, you learned:
 
 * How VM cloning works in OpenShift Virtualization
+* The business scenarios where cloning is the right approach
+* How the web console, CLI DataVolume, and golden image paths compare, and how to choose between them
 * The difference between web console and CLI cloning methods
 * How to clone VMs using the OpenShift web console
 * How to clone VMs using CLI with standalone DataVolumes


### PR DESCRIPTION
## Description

Adds a cloning method comparison diagram, a decision table, and business use cases
to the Cloning VMs tutorial. Addresses issue #226.

## Type of Change

- [x] Enhancement to existing content

## Related Issue

Closes #226

## Content Checklist

### Technical Accuracy
- [x] All commands have been tested on a live cluster  <!-- N/A: no new commands added -->
- [x] YAML manifests are complete and valid (not partial snippets)  <!-- N/A: no manifests added -->
- [x] Technical details verified against official documentation
- [x] Use Professional language

### Testing & Verification
- [x] Verified on OpenShift version: 4.18+  <!-- content is conceptual; no cluster interaction -->
- [x] All verification commands produce expected outputs  <!-- N/A: no new commands -->
- [ ] Screenshots/outputs included (if applicable)  <!-- N/A: uses a text diagram; tutorial's existing screenshots unchanged -->

### Content Quality
- [x] AsciiDoc syntax is correct  <!-- scripts/review-docs.sh: 0 errors -->
- [x] Code blocks specify language (e.g., `[source,yaml]`)  <!-- diagram uses a `....` literal block by design -->
- [x] All internal links (xrefs) are working  <!-- two anchor refs + one cross-page xref -->
- [x] All external links use `window=_blank`  <!-- no external links added; existing unchanged -->
- [x] Navigation (`nav.adoc`) updated if adding new pages  <!-- N/A: editing an existing page -->
- [x] Home page updated if adding new module/tutorial  <!-- N/A: no new module/tutorial -->

### Build & Preview
- [x] `npm run build` completes without errors
- [x] Local preview verified (`npm run serve`)
- [x] No broken xref warnings in build output
- [x] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made

- Added a **Business Use Cases** section with five scenarios (environment provisioning, scale-out testing, cross-namespace deployment, disaster recovery testing, developer sandboxes)
- Added a **Comparing the Cloning Paths** subsection to *Understanding Cloning Methods*, containing a diagram of all three paths with the distinct resources each one creates
- Added a decision table comparing the three methods by best-fit scenario, namespace scope, and RBAC requirement
- Added an IMPORTANT admonition noting that every path produces a full independent copy, with the capacity planning formula
- Added explicit anchors (`[#cloning-across-namespaces]`, `[#storage-space-requirements]`) so the new cross-references resolve reliably
- Updated the *Summary* to reflect the new material