### PR TITLE
Tutorial: Connect to Windows VM via SSH

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for all files in this repository
+* @acmenezes @AdrielMendezRios @yashoza19 @jsm84

--- a/modules/vm-configuration/attachments/ssh-access-windows-vms/windows-ssh-lb-service.yaml
+++ b/modules/vm-configuration/attachments/ssh-access-windows-vms/windows-ssh-lb-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: windows-ssh-lb
+spec:
+  type: LoadBalancer
+  selector:
+    vm.kubevirt.io/name: <your-windows-vm-name>
+  ports:
+    - protocol: TCP
+      port: 22
+      targetPort: 22

--- a/modules/vm-configuration/attachments/ssh-access-windows-vms/windows-ssh-nodeport-service.yaml
+++ b/modules/vm-configuration/attachments/ssh-access-windows-vms/windows-ssh-nodeport-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: windows-ssh-nodeport
+spec:
+  type: NodePort
+  selector:
+    vm.kubevirt.io/name: <your-windows-vm-name>
+  ports:
+    - protocol: TCP
+      port: 22
+      targetPort: 22
+      nodePort: 30022

--- a/modules/vm-configuration/nav.adoc
+++ b/modules/vm-configuration/nav.adoc
@@ -3,6 +3,7 @@
 ** xref:remote-access-linux-vms.adoc[]
 ** xref:remote-access-linux-troubleshooting.adoc[]
 ** xref:remote-access-windows-vms.adoc[]
+** xref:ssh-access-windows-vms.adoc[]
 ** xref:windows-vm-virtio-drivers.adoc[]
 ** xref:infrastructure-node-placement.adoc[]
 ** xref:node-placement-affinity.adoc[]

--- a/modules/vm-configuration/pages/ssh-access-windows-vms.adoc
+++ b/modules/vm-configuration/pages/ssh-access-windows-vms.adoc
@@ -1,0 +1,441 @@
+= Connecting to a Windows VM via SSH
+:navtitle: Remote Access to Windows VMs via SSH
+
+== Overview
+
+Windows 10 (version 1809+) and Windows Server 2019+ include OpenSSH Server as an optional feature. Enabling SSH on a Windows VM gives you a command-line interface you can script against, without requiring Remote Desktop or a graphical session.
+
+This is useful for automation workflows, CI/CD pipelines, and configuration management tools like Ansible that can manage Windows hosts over SSH.
+
+== What You Will Learn
+
+* How to install and configure OpenSSH Server on a Windows VM running in OpenShift Virtualization
+* How to expose the Windows VM SSH port outside the cluster using a Kubernetes Service
+* How to connect to the Windows VM via SSH using password and key-based authentication
+* How to change the default SSH shell to PowerShell
+
+== Prerequisites
+
+* OpenShift 4.18+ with OpenShift Virtualization operator installed
+* A running Windows VM (Windows 10 1809+, Windows 11, or Windows Server 2019/2022/2025) on the cluster
+* VNC or RDP console access to the Windows VM for initial setup
+* CLI tools installed: `oc` and `virtctl`
+* The Windows VM must use the `masquerade` network binding on the pod network (default configuration)
+* The VM spec must declare port 22 on the masquerade interface so the virt-launcher pod creates the NAT forwarding rule (see below)
+
+== Declare Port 22 on the VM Interface
+
+When using masquerade networking, the virt-launcher pod only forwards traffic for ports explicitly listed in the VM spec. If port 22 is not declared, traffic from the Kubernetes Service never reaches the guest, even if sshd is running inside the VM.
+
+Verify that your VirtualMachine spec includes port 22 on the masquerade interface:
+
+[source,yaml]
+----
+spec:
+  template:
+    spec:
+      domain:
+        devices:
+          interfaces:
+            - masquerade: {}
+              name: default
+              ports:
+                - port: 22
+      networks:
+        - name: default
+          pod: {}
+----
+
+If the `ports` section is missing, edit your VirtualMachine to add it:
+
+[source,bash,role=execute]
+----
+oc edit vm <your-windows-vm-name>
+----
+
+Add the `ports` array under the masquerade interface. After saving, restart the VM for the change to take effect:
+
+[source,bash,role=execute]
+----
+virtctl restart <your-windows-vm-name>
+----
+
+== Install OpenSSH Server on the Windows VM
+
+Connect to your Windows VM through the OpenShift console or VNC to run the initial setup commands.
+
+=== Access the VM Console
+
+Open the VM console from the OpenShift web console: **Virtualization** > **VirtualMachines** > select your VM > **Console** tab.
+
+Alternatively, use `virtctl`:
+
+[source,bash,role=execute]
+----
+virtctl vnc <your-windows-vm-name>
+----
+
+=== Check OpenSSH Availability
+
+Open PowerShell as Administrator on the Windows VM and check whether OpenSSH Server is available:
+
+[source,powershell]
+----
+Get-WindowsCapability -Online | Where-Object Name -like 'OpenSSH.Server*'
+----
+
+.Expected output
+[source,text]
+----
+Name  : OpenSSH.Server~~~~0.0.1.0
+State : NotPresent
+----
+
+If the state shows `Installed`, skip to the next section.
+
+=== Install OpenSSH Server
+
+Install the OpenSSH Server feature:
+
+[source,powershell]
+----
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+----
+
+.Expected output
+[source,text]
+----
+Path          :
+Online        : True
+RestartNeeded : False
+----
+
+== Configure the SSH Service
+
+=== Start the SSH Service
+
+Start the `sshd` service and set it to start automatically on boot:
+
+[source,powershell]
+----
+Start-Service sshd
+Set-Service -Name sshd -StartupType Automatic
+----
+
+=== Verify the Service Is Running
+
+[source,powershell]
+----
+Get-Service sshd
+----
+
+.Expected output
+[source,text]
+----
+Status   Name    DisplayName
+Running  sshd    OpenSSH SSH Server
+----
+
+=== Verify the Firewall Rule
+
+The OpenSSH Server installer creates a Windows Firewall rule automatically. Confirm it exists:
+
+[source,powershell]
+----
+Get-NetFirewallRule -Name *OpenSSH-Server* | Select-Object Name, Enabled, Direction, Action
+----
+
+.Expected output
+[source,text]
+----
+Name                  Enabled Direction  Action
+OpenSSH-Server-In-TCP    True   Inbound  Allow
+----
+
+If the rule is missing, create it:
+
+[source,powershell]
+----
+New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+----
+
+=== Fix the Firewall Rule Profile
+
+By default, the OpenSSH firewall rule applies only to the **Private** network profile. However, Windows classifies the KubeVirt masquerade bridge as a **Public** network because it does not recognize the virtual adapter. This mismatch causes Windows Firewall to silently block all inbound SSH connections, even though sshd is running and the rule appears enabled.
+
+Check which profile the rule applies to:
+
+[source,powershell]
+----
+Get-NetFirewallRule -DisplayName "OpenSSH SSH Server (sshd)" | Select-Object DisplayName, Profile
+----
+
+Check the active network profile:
+
+[source,powershell]
+----
+Get-NetConnectionProfile | Select-Object InterfaceAlias, NetworkCategory
+----
+
+If the rule profile is `Private` but the network category is `Public`, update the rule to apply to all profiles:
+
+[source,powershell]
+----
+Set-NetFirewallRule -DisplayName "OpenSSH SSH Server (sshd)" -Profile Any
+----
+
+WARNING: Without this step, SSH connections to the VM will time out even though sshd is running and the firewall rule exists. This is the most common cause of SSH connectivity failures on Windows VMs in OpenShift Virtualization.
+
+== Set PowerShell as the Default Shell
+
+By default, Windows SSH sessions open `cmd.exe`. To use PowerShell instead, run:
+
+[source,powershell]
+----
+New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -PropertyType String -Force
+----
+
+This change takes effect for new SSH sessions. Existing sessions keep their current shell.
+
+== Expose the SSH Port Outside the Cluster
+
+The Windows VM pod network is internal to the cluster. To reach port 22 from outside, create a Kubernetes Service.
+
+=== Option A: NodePort Service
+
+A NodePort Service maps a high-numbered port on every cluster node to port 22 on the VM.
+
+Create the Service manifest:
+
+xref:attachment$ssh-access-windows-vms/windows-ssh-nodeport-service.yaml[Download windows-ssh-nodeport-service.yaml]
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  name: windows-ssh-nodeport
+spec:
+  type: NodePort
+  selector:
+    vm.kubevirt.io/name: <your-windows-vm-name>
+  ports:
+    - protocol: TCP
+      port: 22
+      targetPort: 22
+      nodePort: 30022
+----
+
+NOTE: Replace `<your-windows-vm-name>` with the actual name of your Windows VirtualMachine resource.
+
+Apply the Service:
+
+[source,bash,role=execute]
+----
+oc apply -f windows-ssh-nodeport-service.yaml
+----
+
+Verify the Service:
+
+[source,bash,role=execute]
+----
+oc get svc windows-ssh-nodeport
+----
+
+.Expected output
+[source,text]
+----
+NAME                   TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
+windows-ssh-nodeport   NodePort   172.30.x.x      <none>        22:30022/TCP   5s
+----
+
+Get a node IP address to use for the connection:
+
+[source,bash,role=execute]
+----
+NODE_IP=$(oc get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+echo $NODE_IP
+----
+
+NOTE: The node's `InternalIP` is the routable IP address of the cluster node. Despite the name, this is the address you use to reach NodePort services from outside the cluster. The `ExternalIP` field in `oc get nodes -o wide` is only populated when an external cloud provider assigns one.
+
+=== Option B: LoadBalancer Service
+
+If your cluster has a load balancer provider (such as MetalLB), use a LoadBalancer Service to get a dedicated external IP:
+
+xref:attachment$ssh-access-windows-vms/windows-ssh-lb-service.yaml[Download windows-ssh-lb-service.yaml]
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  name: windows-ssh-lb
+spec:
+  type: LoadBalancer
+  selector:
+    vm.kubevirt.io/name: <your-windows-vm-name>
+  ports:
+    - protocol: TCP
+      port: 22
+      targetPort: 22
+----
+
+NOTE: Replace `<your-windows-vm-name>` with the actual name of your Windows VirtualMachine resource.
+
+Apply the Service:
+
+[source,bash,role=execute]
+----
+oc apply -f windows-ssh-lb-service.yaml
+----
+
+Wait for the external IP to be assigned:
+
+[source,bash,role=execute]
+----
+oc get svc windows-ssh-lb -w
+----
+
+Once the `EXTERNAL-IP` column shows an IP address, press `Ctrl+C` and use that IP to connect.
+
+== Connect to the Windows VM via SSH
+
+=== Connect Using Password Authentication
+
+For a NodePort Service, connect with:
+
+[source,bash]
+----
+ssh <windows-username>@$NODE_IP -p 30022
+----
+
+For a LoadBalancer Service, connect with:
+
+[source,bash]
+----
+ssh <windows-username>@<external-ip>
+----
+
+Replace `<windows-username>` with your Windows account name (for example, `Administrator`) and use the corresponding password when prompted.
+
+=== Connect Using virtctl SSH
+
+If you have cluster access and do not need external exposure, use `virtctl` to SSH through the Kubernetes API server:
+
+[source,bash,role=execute]
+----
+virtctl ssh <windows-username>@<your-windows-vm-name>
+----
+
+This method does not require a Service. It uses API server port-forwarding to reach port 22 on the VM.
+
+== Configure SSH Key Authentication
+
+Password authentication works but is less secure. SSH keys remove the need for interactive password entry and are required for automation tools like Ansible.
+
+=== Generate an SSH Key Pair
+
+On your local machine, generate a key pair if you do not already have one:
+
+[source,bash,role=execute]
+----
+ssh-keygen -t ed25519 -f ~/.ssh/windows-vm-key -N ""
+----
+
+=== Copy the Public Key to the Windows VM
+
+SSH into the Windows VM using password authentication (as described above), then run the following commands in the SSH session.
+
+For a standard (non-administrator) user, add your public key to the `authorized_keys` file:
+
+[source,powershell]
+----
+mkdir -Force $env:USERPROFILE\.ssh
+# Paste your public key content into the authorized_keys file
+Set-Content -Path "$env:USERPROFILE\.ssh\authorized_keys" -Value "ssh-ed25519 AAAA... your-key-here"
+----
+
+For an Administrator account, Windows uses a separate file. Add the key to `administrators_authorized_keys`:
+
+[source,powershell]
+----
+Set-Content -Path "C:\ProgramData\ssh\administrators_authorized_keys" -Value "ssh-ed25519 AAAA... your-key-here"
+
+# Fix permissions so only Administrators and SYSTEM can read the file
+icacls "C:\ProgramData\ssh\administrators_authorized_keys" /inheritance:r /grant "Administrators:F" /grant "SYSTEM:F"
+----
+
+IMPORTANT: The `administrators_authorized_keys` file must have restricted permissions. If the permissions are too open, the SSH server ignores the file and falls back to password authentication.
+
+=== Test Key-Based Login
+
+From your local machine, connect using the key:
+
+[source,bash]
+----
+ssh -i ~/.ssh/windows-vm-key <windows-username>@$NODE_IP -p 30022
+----
+
+If the connection succeeds without a password prompt, key authentication is working.
+
+== Use with Ansible
+
+With SSH configured, you can manage the Windows VM using Ansible over SSH instead of WinRM. Add the host to your inventory:
+
+[source,ini]
+----
+[windows]
+windows-vm ansible_host=<NODE_IP> ansible_port=30022
+
+[windows:vars]
+ansible_user=Administrator
+ansible_ssh_private_key_file=~/.ssh/windows-vm-key
+ansible_shell_type=powershell
+ansible_become_method=runas
+----
+
+Test the connection:
+
+[source,bash]
+----
+ansible windows -m ansible.windows.win_ping
+----
+
+For more details on managing Windows with Ansible over SSH, see the link:https://docs.ansible.com/ansible/latest/os_guide/intro_windows.html#windows-ssh-setup[Ansible Windows SSH documentation,window=_blank].
+
+== Cleanup
+
+Remove the resources created in this tutorial:
+
+[source,bash,role=execute]
+----
+oc delete svc windows-ssh-nodeport windows-ssh-lb
+----
+
+To remove OpenSSH Server from the Windows VM, open PowerShell as Administrator on the VM and run:
+
+[source,powershell]
+----
+Stop-Service sshd
+Remove-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+----
+
+== Summary
+
+* You declared port 22 on the masquerade interface so the virt-launcher pod forwards SSH traffic.
+* You installed OpenSSH Server on a Windows VM running in OpenShift Virtualization.
+* You configured the SSH service to start automatically and fixed the firewall rule to apply to all network profiles.
+* You changed the default SSH shell to PowerShell.
+* You exposed the VM SSH port outside the cluster using a NodePort or LoadBalancer Service.
+* You connected to the Windows VM via SSH using both password and key-based authentication.
+* You saw how to integrate the Windows VM with Ansible over SSH.
+
+== See Also
+
+* xref:remote-access-windows-vms.adoc[Remote Access to Windows VMs via RDP]
+* xref:remote-access-linux-vms.adoc[Remote Access to Linux VMs]
+* link:https://docs.ansible.com/ansible/latest/os_guide/intro_windows.html#windows-ssh-setup[Ansible Windows SSH Setup,window=_blank]
+* link:https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse[Microsoft OpenSSH Installation Guide,window=_blank]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/virtualization/managing-vms[OpenShift Virtualization - Managing VMs,window=_blank]
+


### PR DESCRIPTION
## Summary
  - Adds a Windows module tutorial covering OpenSSH Server installation and
  configuration on Windows VMs
  - Demonstrates SSH access via virtctl, NodePort Service, and LoadBalancer
  Service with key-based authentication
  - Includes downloadable Service YAML attachments for NodePort and
  LoadBalancer configurations

  Closes #20