### PR TITLE
Tutorial: UPDATE Windows golden images guide using Tekton pipeline

### DIFF
--- a/modules/vm-lifecycle/attachments/windows-golden-images/pipelinerun-windows2k25.yaml
+++ b/modules/vm-lifecycle/attachments/windows-golden-images/pipelinerun-windows2k25.yaml
@@ -8,7 +8,7 @@ spec:
     - name: winImageDownloadURL
       value: "REPLACE_WITH_YOUR_ISO_URL"
     - name: acceptEula
-      value: "true"
+      value: "false"
     - name: preferenceName
       value: windows.2k25.virtio
     - name: autounattendConfigMapName

--- a/modules/vm-lifecycle/pages/windows-golden-images.adoc
+++ b/modules/vm-lifecycle/pages/windows-golden-images.adoc
@@ -270,6 +270,9 @@ The PowerShell script runs as SYSTEM in Audit mode and performs four tasks:
 
 Replace `REPLACE_WITH_YOUR_ISO_URL` in the following manifest with the URL you copied in Step 2.
 
+NOTE: Example PipelineRuns have special parameter acceptEula. By setting this parameter, you are agreeing to the applicable Microsoft end user license agreement(s) for each deployment or installation for the Microsoft product(s). In case you set it to false, the Pipeline will exit in first task.
+
+
 xref:attachment$windows-golden-images/pipelinerun-windows2k25.yaml[Download pipelinerun-windows2k25.yaml]
 
 [source,yaml]
@@ -284,7 +287,7 @@ spec:
     - name: winImageDownloadURL
       value: "REPLACE_WITH_YOUR_ISO_URL"
     - name: acceptEula
-      value: "true"
+      value: "false"
     - name: preferenceName
       value: windows.2k25.virtio
     - name: autounattendConfigMapName


### PR DESCRIPTION


## Description

The `acceptEula` parameter must not be set by default in tutorials and templates to enforce the user is aware of it. Accapting the EULA might create a contract between the legal entiy of the user and Microsoft.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [X] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

no issue created

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [X] YAML manifests are complete and valid (not partial snippets)
- [X] Technical details verified against official documentation
- [X] Use Professional language

### Testing & Verification
- [ ] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [ ] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [ ] All internal links (xrefs) are working
- [ ] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

### Build & Preview
- [ ] `npm run build` completes without errors
- [ ] Local preview verified (`npm run serve`)
- [ ] No broken xref warnings in build output
- [ ] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made

<!-- Provide a bullet-point list of changes -->

- `acceptEula` set to `false` by default

## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

