### PR TITLE
Use instancetype and preference in Windows VM definitions

### DIFF
--- a/modules/vm-configuration/attachments/windows-vm-virtio-drivers/windows-vm-virtio.yaml
+++ b/modules/vm-configuration/attachments/windows-vm-virtio-drivers/windows-vm-virtio.yaml
@@ -6,76 +6,23 @@ metadata:
     app: windows-vm-virtio
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.large
+  preference:
+    name: windows.2k25.virtio
   template:
-    metadata:
-      labels:
-        kubevirt.io/size: medium
-        kubevirt.io/domain: windows-vm-virtio
-        vm.kubevirt.io/name: windows-vm-virtio
     spec:
       domain:
-        cpu:
-          cores: 2
-          sockets: 1
-          threads: 2
-        resources:
-          requests:
-            memory: 4Gi
         devices:
           disks:
             - name: rootdisk
-              disk:
-                bus: virtio
+              disk: {}
               bootOrder: 2
             - name: windows-installation-iso
-              cdrom:
-                bus: sata
+              cdrom: {}
               bootOrder: 1
             - name: virtio-drivers-iso
-              cdrom:
-                bus: sata
-          interfaces:
-            - name: default
-              masquerade: {}
-              model: virtio
-          tpm: {}
-          rng: {}
-        clock:
-          utc: {}
-          timer:
-            hpet:
-              present: false
-            pit:
-              tickPolicy: delay
-            rtc:
-              tickPolicy: catchup
-            hyperv: {}
-        features:
-          acpi: {}
-          apic: {}
-          hyperv:
-            relaxed: {}
-            vapic: {}
-            spinlocks:
-              spinlocks: 8191
-            vpindex: {}
-            runtime: {}
-            synic: {}
-            stimer: {}
-            reset: {}
-            frequencies: {}
-            reenlightenment: {}
-            tlbflush: {}
-            ipi: {}
-          smm:
-            enabled: true
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: true
-      networks:
-        - name: default
-          pod: {}
+              cdrom: {}
       volumes:
         - name: rootdisk
           dataVolume:

--- a/modules/vm-configuration/pages/windows-vm-virtio-drivers.adoc
+++ b/modules/vm-configuration/pages/windows-vm-virtio-drivers.adoc
@@ -113,76 +113,23 @@ metadata:
     app: windows-vm-virtio
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.large
+  preference:
+    name: windows.2k25.virtio
   template:
-    metadata:
-      labels:
-        kubevirt.io/size: medium
-        kubevirt.io/domain: windows-vm-virtio
-        vm.kubevirt.io/name: windows-vm-virtio
     spec:
       domain:
-        cpu:
-          cores: 2
-          sockets: 1
-          threads: 2
-        resources:
-          requests:
-            memory: 4Gi
         devices:
           disks:
             - name: rootdisk
-              disk:
-                bus: virtio
+              disk: {}
               bootOrder: 2
             - name: windows-installation-iso
-              cdrom:
-                bus: sata
+              cdrom: {}
               bootOrder: 1
             - name: virtio-drivers-iso
-              cdrom:
-                bus: sata
-          interfaces:
-            - name: default
-              masquerade: {}
-              model: virtio
-          tpm: {}
-          rng: {}
-        clock:
-          utc: {}
-          timer:
-            hpet:
-              present: false
-            pit:
-              tickPolicy: delay
-            rtc:
-              tickPolicy: catchup
-            hyperv: {}
-        features:
-          acpi: {}
-          apic: {}
-          hyperv:
-            relaxed: {}
-            vapic: {}
-            spinlocks:
-              spinlocks: 8191
-            vpindex: {}
-            runtime: {}
-            synic: {}
-            stimer: {}
-            reset: {}
-            frequencies: {}
-            reenlightenment: {}
-            tlbflush: {}
-            ipi: {}
-          smm:
-            enabled: true
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: true
-      networks:
-        - name: default
-          pod: {}
+              cdrom: {}
       volumes:
         - name: rootdisk
           dataVolume:

--- a/modules/vm-lifecycle/attachments/windows-golden-images/windows-vm-from-golden.yaml
+++ b/modules/vm-lifecycle/attachments/windows-golden-images/windows-vm-from-golden.yaml
@@ -19,68 +19,19 @@ spec:
             requests:
               storage: 60Gi
   runStrategy: RerunOnFailure
+  instancetype:
+    name: u1.large
+  preference:
+    name: windows.2k25.virtio
   template:
-    metadata:
-      labels:
-        kubevirt.io/domain: win2k25-vm-1
     spec:
       domain:
-        cpu:
-          cores: 2
-          sockets: 1
-          threads: 2
-        memory:
-          guest: 4Gi
         devices:
           disks:
             - name: rootdisk
-              disk:
-                bus: virtio
+              disk: {}
             - name: sysprep
-              cdrom:
-                bus: sata
-          interfaces:
-            - name: default
-              masquerade: {}
-              model: virtio
-          tpm: {}
-          rng: {}
-        clock:
-          utc: {}
-          timer:
-            hpet:
-              present: false
-            pit:
-              tickPolicy: delay
-            rtc:
-              tickPolicy: catchup
-            hyperv: {}
-        features:
-          acpi: {}
-          apic: {}
-          hyperv:
-            relaxed: {}
-            vapic: {}
-            spinlocks:
-              spinlocks: 8191
-            vpindex: {}
-            runtime: {}
-            synic: {}
-            stimer: {}
-            reset: {}
-            frequencies: {}
-            reenlightenment: {}
-            tlbflush: {}
-            ipi: {}
-          smm:
-            enabled: true
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: true
-      networks:
-        - name: default
-          pod: {}
+              cdrom: {}
       volumes:
         - name: rootdisk
           dataVolume:

--- a/modules/vm-lifecycle/pages/windows-golden-images.adoc
+++ b/modules/vm-lifecycle/pages/windows-golden-images.adoc
@@ -490,7 +490,7 @@ oc apply -f sysprep-unattend-configmap.yaml
 
 === Create the VM
 
-The VM below clones its root disk from the `win2k25` DataSource and attaches the sysprep ConfigMap as a volume. The hardware configuration includes Hyper-V enlightenments, EFI with Secure Boot, TPM, and VirtIO devices.
+The VM below clones its root disk from the `win2k25` DataSource and attaches the sysprep ConfigMap as a volume. The `windows.2k25.virtio` preference provides the Windows-specific hardware configuration (Hyper-V enlightenments, EFI with Secure Boot, TPM, VirtIO device buses, clock and timer settings), and the `u1.large` instancetype defines CPU and memory resources.
 
 xref:attachment$windows-golden-images/windows-vm-from-golden.yaml[Download windows-vm-from-golden.yaml]
 
@@ -517,68 +517,19 @@ spec:
             requests:
               storage: 60Gi
   runStrategy: RerunOnFailure
+  instancetype:
+    name: u1.large
+  preference:
+    name: windows.2k25.virtio
   template:
-    metadata:
-      labels:
-        kubevirt.io/domain: win2k25-vm-1
     spec:
       domain:
-        cpu:
-          cores: 2
-          sockets: 1
-          threads: 2
-        memory:
-          guest: 4Gi
         devices:
           disks:
             - name: rootdisk
-              disk:
-                bus: virtio
+              disk: {}
             - name: sysprep
-              cdrom:
-                bus: sata
-          interfaces:
-            - name: default
-              masquerade: {}
-              model: virtio
-          tpm: {}
-          rng: {}
-        clock:
-          utc: {}
-          timer:
-            hpet:
-              present: false
-            pit:
-              tickPolicy: delay
-            rtc:
-              tickPolicy: catchup
-            hyperv: {}
-        features:
-          acpi: {}
-          apic: {}
-          hyperv:
-            relaxed: {}
-            vapic: {}
-            spinlocks:
-              spinlocks: 8191
-            vpindex: {}
-            runtime: {}
-            synic: {}
-            stimer: {}
-            reset: {}
-            frequencies: {}
-            reenlightenment: {}
-            tlbflush: {}
-            ipi: {}
-          smm:
-            enabled: true
-        firmware:
-          bootloader:
-            efi:
-              secureBoot: true
-      networks:
-        - name: default
-          pod: {}
+              cdrom: {}
       volumes:
         - name: rootdisk
           dataVolume:


### PR DESCRIPTION
Replace expanded inline domain specs with instancetype and preference
references in both Windows VM examples. The windows.2k25.virtio
preference provides all Windows-specific settings (Hyper-V
enlightenments, EFI/SecureBoot firmware, clock/timer configuration,
VirtIO disk and SATA cdrom bus types, masquerade networking), and the
u1.large instancetype defines CPU and memory resources (8Gi).

This removes ~50 lines of boilerplate per VM while producing identical
runtime configurations.

Verified on OpenShift 4.22 cluster (Azure, 3 workers + 1 Windows node):

- windows-vm-virtio: created with blank root disk, Windows 2025 ISO
  cloned from openshift-virtualization-os-images/windows2k25-iso, and
  virtio-win ISO imported from fedorapeople.org. VM reached Running/Ready
  state. Preference correctly applied Hyper-V enlightenments (relaxed,
  vapic, spinlocks 8191, synic, synictimer, tlbflush, ipi, frequencies,
  reenlightenment, reset, runtime, vpindex), EFI with SecureBoot, and
  clock timers. Disk buses: virtio for disks, sata for cdroms.

- win2k25-vm-1: created from win2k25 golden image DataSource with
  sysprep ConfigMap. Storage adjusted to 65Gi for verification (source
  PVC is 64Gi; the tutorial's 60Gi value depends on the golden image
  size at the user's site). VM reached Running/Ready state with identical
  preference-applied settings.

Inline YAML in both .adoc pages verified to match their attachment
YAML files exactly.