### PR TITLE
Add virtctl expose option for Windows RDP service creation

### DIFF
--- a/modules/vm-configuration/pages/remote-access-windows-vms.adoc
+++ b/modules/vm-configuration/pages/remote-access-windows-vms.adoc
@@ -132,6 +132,15 @@ spec:
 oc apply -f rdp-service.yaml
 ----
 
+===== Option C: Using virtctl
+
+[source,bash,role=execute]
+----
+virtctl expose vm <your-vm-name> --port=3389 --name=<your-vm-name>-rdp-service --type=LoadBalancer
+----
+
+Replace `<your-vm-name>` with your VM's actual name. For NodePort instead of LoadBalancer, use `--type=NodePort`.
+
 ==== Step 3: Obtain Connection Details
 
 ===== For LoadBalancer Service:


### PR DESCRIPTION
  ## Summary

  - Add Option C (`virtctl expose`) to the Windows RDP remote access tutorial as a simpler alternative to writing a Service YAML manifest

  ## Details

  The tutorial previously offered two ways to create the RDP LoadBalancer/NodePort service:
  - **Option A**: OpenShift Web Console UI
  - **Option B**: `oc apply -f rdp-service.yaml`

  This adds **Option C** using `virtctl expose vm`, which achieves the same result in a single command without needing to author a YAML file.


