### PR TITLE
add CODEOWNERS to project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for all files in this repository
+* @acmenezes @AdrielMendezRios @yashoza19 @jsm84


### PR DESCRIPTION
Add CODEOWNERS to project. Review must be done by one of those team members.