### PR TITLE
Escape attribute references in create-vm-web-console

### DIFF
--- a/modules/getting-started/pages/create-vm-web-console.adoc
+++ b/modules/getting-started/pages/create-vm-web-console.adoc
@@ -108,7 +108,7 @@ A VM template is an OpenShift Template resource that wraps a VirtualMachine mani
 
 A template differs from a raw VirtualMachine manifest in three ways:
 
-* **Parameters** -- Fields like `${NAME}` and `${DATA_SOURCE_NAME}` are replaced at creation time. This allows one template to produce many VMs with different names and configurations.
+* **Parameters** -- Fields like `$\{NAME}` and `$\{DATA_SOURCE_NAME}` are replaced at creation time. This allows one template to produce many VMs with different names and configurations.
 * **DataSource references** -- Instead of specifying a disk image URL or PVC directly, templates reference a DataSource in the `openshift-virtualization-os-images` namespace. The DataSource abstracts the boot image location, so templates stay valid even when the underlying golden image is updated.
 * **Web console annotations** -- Templates carry annotations such as `template.kubevirt.io/type`, `name.os.template.kubevirt.io`, and `description` that tell the web console how to display the template in the catalog, which icon to show, and what default values to present.
 


### PR DESCRIPTION
## Description
Follow up on build warnings caused by changes introduced in #311.

```
> build
> antora --attribute build-date="$(date +'%Y-%m-%d %H:%M')" antora-playbook.yml

(node:45966) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)
[10:03:05.103] WARN (asciidoctor): skipping reference to missing attribute: name
    file: /Users/caxu/ocp-virt-cookbook/modules/getting-started/pages/create-vm-web-console.adoc
    source: /Users/caxu/ocp-virt-cookbook (branch: main <worktree>)
[10:03:05.104] WARN (asciidoctor): skipping reference to missing attribute: data_source_name
    file: /Users/caxu/ocp-virt-cookbook/modules/getting-started/pages/create-vm-web-console.adoc
    source: /Users/caxu/ocp-virt-cookbook (branch: main <worktree>)
Site generation complete!
```

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [x] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

None

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [ ] Technical details verified against official documentation
- [ ] Use Professional language

### Testing & Verification
- [ ] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [x] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [ ] All internal links (xrefs) are working
- [ ] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

### Build & Preview
- [x] `npm run build` completes without errors
- [x] Local preview verified (`npm run serve`)
- [ ] No broken xref warnings in build output
- [ ] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made

<!-- Provide a bullet-point list of changes -->

- Escaped the `${NAME}` and `${DATA_SOURCE_NAME}` text to avoid Asciidoctor interpreting them as attributes

## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

