### PR TITLE
Check for minimum compatible Bash version in review-docs script

### DIFF
--- a/scripts/review-docs.sh
+++ b/scripts/review-docs.sh
@@ -9,6 +9,12 @@ set -euo pipefail
 # Exit code: 0 if no errors, 1 if any ERROR-level issues found.
 # Warnings alone do NOT cause non-zero exit.
 
+# Requires Bash 4+ for associative arrays, mapfile, and negative indexing.
+if [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then
+    echo "Error: This script requires Bash 4 or later (found ${BASH_VERSION})." >&2
+    exit 1
+fi
+
 # ── Configuration ─────────────────────────────────────────────────────────────
 
 # Product name patterns to check (case-sensitive)


### PR DESCRIPTION
## Description

<!-- Provide a brief description of your changes -->
The `scripts/review-docs.sh` script relies on Bash features only present in version 4 or newer. Some environments (notably macOS) only provide older versions. Notify user with a descriptive error message if a user uses too old of a Bash version.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [x] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

<!-- Link to the issue this PR addresses -->
None

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [ ] Technical details verified against official documentation
- [ ] Use Professional language

### Testing & Verification
- [ ] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [ ] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [ ] All internal links (xrefs) are working
- [ ] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

### Build & Preview
- [ ] `npm run build` completes without errors
- [ ] Local preview verified (`npm run serve`)
- [ ] No broken xref warnings in build output
- [ ] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made

- Add conditional check in `scripts/review-docs.sh` to check for compatible Bash version

## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

