### PR TITLE
feat(review-docs): add list-blank-line check

### DIFF
--- a/.review-docs.conf
+++ b/.review-docs.conf
@@ -22,6 +22,7 @@
 # product-names = warning
 # banned-terms = warning
 # admonition-capitalization = warning
+# list-blank-line = warning
 #
 # ── Code block checks ──
 # code-block-language = warning

--- a/scripts/review_docs/checks/prose.py
+++ b/scripts/review_docs/checks/prose.py
@@ -223,3 +223,104 @@ def check_admonition_capitalization(
             f"line {line_num}: Admonition should be followed by capitalized word: {admonition}: {first_char}",
         )
 
+
+@register_check("list-blank-line", "warning", "prose")
+def check_list_blank_line(
+    line: str,
+    line_num: int,
+    state: ParseState,
+    cfg: Config,
+    file_result: FileResult,
+) -> None:
+    """Check that lists are preceded by a blank line.
+
+    In AsciiDoc, a list immediately following a non-blank line (such as a
+    paragraph) is not rendered as a list.  A blank line is required before
+    the first list item.
+
+    Uses ``state.in_list`` to track whether we are currently inside a
+    list context (i.e. the list has already started).  Multi-line list item
+    paragraphs (no ``+`` needed) followed by another list marker are valid
+    AsciiDoc and should not be flagged.
+    """
+    # Matches the start of any AsciiDoc list item.  Derived from the
+    # ``UnorderedListRx`` and ``OrderedListRx`` patterns in Asciidoctor's
+    # ``rx.rb``.  Description lists (``term::``) and callout lists
+    # (``<1>``) are handled separately.
+    #
+    # Unordered : ``-``, ``*`` through ``*****``, ``•`` (U+2022)
+    # Ordered   : ``.`` through ``......`` (dot-style)
+    #             ``1.`` (arabic), ``a.``/``A.`` (alpha)
+    #             ``i)``/``iv)`` (lowerroman), ``I)``/``IV)`` (upperroman)
+    _LIST_ITEM_RE = r"^\s*(-|\*{1,5}|\u2022|\.{1,6}|\d+\.|[a-zA-Z]\.|[IVXivx]+\))\s+"
+
+    is_list_item = bool(re.match(_LIST_ITEM_RE, line))
+
+    # Track list context: we leave it on a blank line.
+    if not line.strip():
+        state.in_list = False
+        return
+
+    # A list continuation marker (+) means we're in a list.
+    if line.strip() == "+":
+        state.in_list = True
+        return
+
+    if is_list_item:
+        # If we're already in a list, this is a continuation — always OK.
+        if state.in_list:
+            return
+    else:
+        # Non-list, non-blank line: leave context unchanged (multi-line
+        # paragraph continuation within a list item is fine).
+        return
+
+    # --- We have a list item and we are NOT already in a list context ---
+    prev_line = state.prev_line
+
+    # Previous line is blank -> OK (already handled above, but defensive)
+    if not prev_line.strip():
+        state.in_list = True
+        return
+
+    # Previous line is itself a list item -> OK (start of list context)
+    if re.match(_LIST_ITEM_RE, prev_line):
+        state.in_list = True
+        return
+
+    # Previous line is a list continuation marker -> OK
+    if prev_line.strip() == "+":
+        state.in_list = True
+        return
+
+    # Previous line is a description list term (ends with ::) -> OK
+    if prev_line.rstrip().endswith("::"):
+        state.in_list = True
+        return
+
+    # Previous line is a heading -> OK (lists can follow headings)
+    if re.match(r"^=+\s+", prev_line):
+        state.in_list = True
+        return
+
+    # Previous line is a block delimiter -> OK (lists inside admonition/sidebar/etc.)
+    # The engine consumes delimiter lines before prose checks run, but
+    # ``prev_line`` is still set to the delimiter text.
+    if re.match(r"^(====|----|\.\.\.\.|(\*{4}|\+{4}|_{4})|--|\|===)\s*$", prev_line):
+        state.in_list = True
+        return
+
+    # Previous line is an attribute/anchor/block-title -> OK
+    if re.match(r"^(\[|:|\.|//)", prev_line):
+        state.in_list = True
+        return
+
+    file_result.add_finding(
+        cfg,
+        "list-blank-line",
+        line_num,
+        f"line {line_num}: List not preceded by blank line (will not render as a list in AsciiDoc)",
+    )
+    # Even though we flagged it, the list has started from this point.
+    state.in_list = True
+

--- a/scripts/review_docs/engine.py
+++ b/scripts/review_docs/engine.py
@@ -57,6 +57,7 @@ _BLOCK_DELIMITERS = {
 }
 
 
+
 # ── Internal helpers ──────────────────────────────────────────────────────────
 
 
@@ -112,6 +113,7 @@ def _check_block_boundary(line: str, state: ParseState) -> bool:
                 state.block_stack.append(block_type)
             return True
     return False
+
 
 
 # ── Public API ────────────────────────────────────────────────────────────────

--- a/scripts/review_docs/models.py
+++ b/scripts/review_docs/models.py
@@ -56,7 +56,6 @@ class ParseState:
         Convenience property — equivalent to ``self.in_block("code_block")``.
         """
         return self.in_block("code_block")
-
     # ── Per-check private state ──────────────────────────────────────
     _check_state: Dict[str, Dict[str, Any]] = field(
         default_factory=dict, repr=False


### PR DESCRIPTION
## Description

<!-- Provide a brief description of your changes -->
Add a new prose check that detects list items (*, -, .) not preceded by a blank line. In AsciiDoc, a list immediately following a paragraph line is not rendered as a list; a blank line is required before the first list item.

This addresses the pattern fixed in PRs #325, #292, #291, #290, #289.

The check allows lists after: blank lines, other list items, headings, continuation markers (+), and attributes/anchors/block-titles.

Default severity: warning.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [ ] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

Part of #336.

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [ ] Technical details verified against official documentation
- [ ] Use Professional language

### Testing & Verification
- [ ] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [ ] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [ ] All internal links (xrefs) are working
- [ ] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

### Build & Preview
- [ ] `npm run build` completes without errors
- [ ] Local preview verified (`npm run serve`)
- [ ] No broken xref warnings in build output
- [ ] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made

<!-- Provide a bullet-point list of changes -->

- Add a new prose check that detects list items (*, -, .) not preceded by a blank line

## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

