### PR TITLE
refactor(review-docs): refactor checks state management

### DIFF
--- a/scripts/review_docs/WRITING_CHECKS.md
+++ b/scripts/review_docs/WRITING_CHECKS.md
@@ -1,0 +1,472 @@
+# Writing Checks for review_docs
+
+This guide covers everything you need to add a new check to the
+documentation review tool. It focuses on the interfaces and data
+structures available to check authors.
+
+## Quick start
+
+1. Choose a scope (see [Scopes](#scopes)).
+2. Write a function with the matching signature.
+3. Decorate it with `@register_check(name, severity, scope)`.
+4. Place it in the appropriate module under `checks/`.
+5. If the module is new, import it in `checks/__init__.py`.
+6. Add a commented-out entry to `.review-docs.conf`.
+
+That is all. The engine discovers checks automatically at import time
+through the decorator — no wiring, no manual registration.
+
+---
+
+## The `@register_check` decorator
+
+```python
+from ..registry import register_check
+from ..config import Config
+from ..models import FileResult, ParseState
+
+@register_check("my-check", "warning", "prose")
+def check_something(line: str, line_num: int, state: ParseState, cfg: Config, file_result: FileResult) -> None:
+    ...
+```
+
+**Parameters:**
+
+| Parameter  | Type   | Description |
+|------------|--------|-------------|
+| `name`     | `str`  | Unique identifier, kebab-case (e.g. `"my-new-check"`). Used in CLI flags, config file, and findings output. |
+| `severity` | `str`  | Default severity: `"error"` or `"warning"`. Users can override this in `.review-docs.conf` or via `--disable`. |
+| `scope`    | `str`  | Determines when the engine calls your function. One of: `"prose"`, `"code_block_content"`, `"code_block_boundary"`, `"structural"`. |
+
+The decorator validates your function's parameter names against the
+expected signature for the given scope. If they don't match, a
+`TypeError` is raised at import time — you'll see it immediately.
+
+---
+
+## Scopes
+
+Each scope corresponds to a different point in the engine's line-by-line
+state machine. Choose the scope that matches what your check needs to
+inspect.
+
+### `prose`
+
+**When it runs:** On every line that is outside a code block, outside a
+block delimiter, and not a comment (`//`).
+
+**Signature:**
+
+```python
+def check_name(line: str, line_num: int, state: ParseState, cfg: Config, file_result: FileResult) -> None
+```
+
+Most checks are prose checks. Use this scope for anything that examines
+documentation text: style, formatting, terminology, heading structure.
+
+### `code_block_content`
+
+**When it runs:** On every line *inside* a `----`-delimited code block
+(not including the delimiter lines themselves).
+
+**Signature:** Same as `prose`.
+
+The `state.code_block_lang` attribute tells you the language from the
+`[source,lang]` specifier. Use it to limit your check to specific
+languages:
+
+```python
+@register_check("yaml-something", "warning", "code_block_content")
+def check_yaml_something(line: str, line_num: int, state: ParseState, cfg: Config, file_result: FileResult) -> None:
+    if state.code_block_lang != "yaml":
+        return
+    # ... inspect line ...
+```
+
+### `code_block_boundary`
+
+**When it runs:** Once each time a `----` delimiter is encountered
+(both opening and closing).
+
+**Signature:** Same as `prose`.
+
+Use `state.boundary_direction` to distinguish:
+
+- `"open"` — the `----` that starts a code block
+- `"close"` — the `----` that ends a code block
+
+On open, `state.prev_line` contains the line immediately before the
+delimiter — typically the `[source,lang]` attribute, which you can
+inspect.
+
+### `structural`
+
+**When it runs:** Once per file, after all line-by-line processing is
+complete. Receives the full file content.
+
+**Signature:**
+
+```python
+def check_name(filepath: str, lines: list[str], cfg: Config, file_result: FileResult) -> None
+```
+
+Use this for checks that need the whole file: validating required
+sections exist, cross-referencing with the filesystem, parsing
+multi-line constructs that span the entire document.
+
+---
+
+## Data structures
+
+### `ParseState`
+
+The engine maintains a single `ParseState` instance per file and passes
+it to every line-level check. It carries the parser's current position
+and context.
+
+**Attributes you can read:**
+
+| Attribute              | Type         | Description |
+|------------------------|--------------|-------------|
+| `prev_line`            | `str`        | The previous line's text. Set by the engine at the end of each iteration. |
+| `in_code_block`        | `bool`       | Whether we are currently inside a `----` code block. Convenience property — equivalent to `in_block("code_block")`. |
+| `code_block_lang`      | `str`        | Language from `[source,lang]`, or `""` if none. Only meaningful when `in_code_block` is `True`. |
+| `code_block_start_line`| `int`        | Line number of the opening `----`. |
+| `boundary_direction`   | `str`        | `"open"` or `"close"` — only meaningful inside `code_block_boundary` checks. |
+| `heading_levels`       | `list[int]`  | Stack of heading levels seen so far (1 = `=`, 2 = `==`, etc.). |
+| `first_heading_found`  | `bool`       | Whether any heading has been encountered yet. |
+| `h1_count`             | `int`        | Number of H1 (`=`) headings seen. |
+| `in_list`              | `bool`       | Whether we are currently in a list context. |
+| `block_stack`          | `list[str]`  | Stack of currently open block types (see below). |
+
+**Block stack:** The engine tracks all block delimiters — including code
+blocks — as they open and close. The recognized block types are:
+
+| Delimiter | Block type      |
+|-----------|-----------------|
+| `----`    | `"code_block"`  |
+| `\|===`   | `"table"`       |
+| `====`    | `"admonition"`  |
+| `****`    | `"sidebar"`     |
+| `++++`    | `"passthrough"` |
+| `....`    | `"literal"`     |
+| `--`      | `"open"`        |
+
+You can query block context with:
+
+```python
+if state.in_block("table"):
+    return  # skip this check inside tables
+
+if state.in_code_block:  # equivalent to state.in_block("code_block")
+    ...
+
+if state.block_stack:  # we're inside some kind of block (including code blocks)
+    ...
+```
+
+**Per-check private state:** If your check needs to track state across
+lines (counters, flags, accumulators), use `state.check_state(name)`
+to get a private dict scoped to your check:
+
+```python
+@register_check("my-check", "warning", "prose")
+def check_something(line: str, line_num: int, state: ParseState, cfg: Config, file_result: FileResult) -> None:
+    my_state = state.check_state("my-check")
+
+    if "counter" not in my_state:
+        my_state["counter"] = 0
+
+    my_state["counter"] += 1
+    # ...
+```
+
+This avoids polluting shared `ParseState` attributes. Each check gets
+its own namespace; the dict is created lazily on first access.
+
+### `Config`
+
+The merged configuration from config file + CLI overrides. Check authors
+typically use two methods:
+
+| Method                      | Returns  | Description |
+|-----------------------------|----------|-------------|
+| `cfg.is_enabled(check_name)`| `bool`   | Whether the check is active. You rarely need this — the engine already skips disabled checks. |
+| `cfg.severity(check_name)`  | `str`    | The effective severity (`"error"`, `"warning"`, or `"disable"`). Used internally by `add_finding`. |
+
+For checks that use configurable term lists:
+
+| Attribute        | Type            | Description |
+|------------------|-----------------|-------------|
+| `cfg.product_names` | `dict[str, str]` | Maps incorrect product names to their correct forms. |
+| `cfg.banned_terms`  | `dict[str, str]` | Maps banned terms to suggested replacements. |
+
+### `FileResult`
+
+Accumulates findings for a single file. The primary method you'll use:
+
+```python
+file_result.add_finding(cfg, "my-check", line_num, "Description of the problem")
+```
+
+**Parameters:**
+
+| Parameter    | Type          | Description |
+|--------------|---------------|-------------|
+| `cfg`        | `Config`      | Passed through to determine effective severity. |
+| `check_name` | `str`         | Must match the name in your `@register_check`. |
+| `line_num`   | `int \| None` | Line number (1-indexed), or `None` for file-level findings. |
+| `message`    | `str`         | Human-readable description of the issue. |
+
+You don't need to construct `Finding` objects directly — `add_finding`
+handles that.
+
+---
+
+## Writing a check: step by step
+
+### Example: a prose check
+
+Suppose you want to warn when a line contains a TODO comment in the
+rendered text (outside code blocks).
+
+```python
+# checks/prose.py
+
+import re
+from ..config import Config
+from ..models import FileResult, ParseState
+from ..registry import register_check
+
+
+@register_check("todo-comments", "warning", "prose")
+def check_todo_comments(line: str, line_num: int, state: ParseState, cfg: Config, file_result: FileResult) -> None:
+    """Flag TODO/FIXME markers in prose text."""
+    if re.search(r"\bTODO\b|\bFIXME\b", line, re.IGNORECASE):
+        file_result.add_finding(
+            cfg,
+            "todo-comments",
+            line_num,
+            f"line {line_num}: TODO/FIXME marker found in prose",
+        )
+```
+
+That's it. The decorator registers it, the engine calls it on every
+prose line, and findings appear in the output automatically.
+
+### Example: a structural check
+
+Suppose you want to verify that every page file has a top-level heading.
+
+```python
+# checks/structural.py
+
+import re
+from typing import List
+from ..config import Config
+from ..models import FileResult
+from ..registry import register_check
+
+
+@register_check("require-title", "error", "structural")
+def check_require_title(filepath: str, lines: List[str], cfg: Config, file_result: FileResult) -> None:
+    """Ensure every .adoc file has a document title (= heading)."""
+    for line in lines:
+        if re.match(r"^= \S", line):
+            return  # found a title
+    file_result.add_finding(
+        cfg,
+        "require-title",
+        None,
+        "File has no document title (= heading)",
+    )
+```
+
+Structural checks receive `filepath` as a string and `lines` as a
+`list[str]` (already split, no trailing newlines).
+
+### Example: using per-check state
+
+A check that counts consecutive blank lines and warns if there are more
+than two:
+
+```python
+@register_check("excessive-blank-lines", "warning", "prose")
+def check_excessive_blank_lines(line: str, line_num: int, state: ParseState, cfg: Config, file_result: FileResult) -> None:
+    """Warn on 3+ consecutive blank lines."""
+    my = state.check_state("excessive-blank-lines")
+
+    if not line.strip():
+        my["count"] = my.get("count", 0) + 1
+    else:
+        if my.get("count", 0) >= 3:
+            file_result.add_finding(
+                cfg,
+                "excessive-blank-lines",
+                line_num - 1,
+                f"line {line_num - 1}: {my['count']} consecutive blank lines",
+            )
+        my["count"] = 0
+```
+
+### Example: using block context
+
+A check that only applies outside of tables:
+
+```python
+@register_check("no-bare-emphasis", "warning", "prose")
+def check_no_bare_emphasis(line: str, line_num: int, state: ParseState, cfg: Config, file_result: FileResult) -> None:
+    """Flag bare emphasis markers that may not render correctly."""
+    if state.in_block("table"):
+        return  # table cells have different formatting rules
+
+    if re.search(r"(?<!\w)_[^_]+_(?!\w)", line):
+        file_result.add_finding(
+            cfg,
+            "no-bare-emphasis",
+            line_num,
+            f"line {line_num}: Possible bare emphasis (use *bold* or `mono` for clarity)",
+        )
+```
+
+---
+
+## Adding a check to a new module
+
+If your check doesn't belong in `prose.py`, `code_blocks.py`, or
+`structural.py`, create a new module:
+
+```
+checks/
+  __init__.py
+  prose.py
+  code_blocks.py
+  structural.py
+  my_checks.py          <-- new file
+```
+
+Then add the import to `checks/__init__.py`:
+
+```python
+from . import code_blocks  # noqa: F401
+from . import prose  # noqa: F401
+from . import structural  # noqa: F401
+from . import my_checks  # noqa: F401
+```
+
+The import triggers `@register_check` at package load time, which is
+all that's needed.
+
+---
+
+## Updating `.review-docs.conf`
+
+Add a commented-out entry for your new check in the appropriate section
+of `.review-docs.conf` at the repo root. This documents the check's
+existence and its default severity:
+
+```ini
+[checks]
+# ── Prose checks (run on lines outside code blocks) ──
+# ...existing entries...
+# todo-comments = warning
+```
+
+---
+
+## Severity guidelines
+
+| Severity    | Use when |
+|-------------|----------|
+| `"error"`   | The issue will cause incorrect rendering, broken links, or content that misleads readers. The CI pipeline fails on errors. |
+| `"warning"` | The issue is a style or quality concern that should be fixed but doesn't break anything. Warnings alone never cause CI failure. |
+
+Prefer `"warning"` as the default unless the check detects something
+that is unambiguously broken. Users can promote any warning to an error
+in their config file.
+
+---
+
+## Message format conventions
+
+Findings messages should be concise and actionable. For line-level
+checks, prefix the message with `line {line_num}:` for consistent
+output:
+
+```python
+f"line {line_num}: Trailing whitespace"
+f"line {line_num}: '{wrong}' should be '{correct}'"
+f"line {line_num}: Code block delimiter without [source,language] specifier"
+```
+
+For structural (file-level) checks where `line_num` is `None`, omit
+the prefix:
+
+```python
+"File does not end with a newline character"
+"Tutorial page missing '== Prerequisites' section"
+```
+
+---
+
+## Signature validation
+
+The decorator validates your function's parameter **names** at import
+time. If you misspell a parameter or use the wrong signature for your
+scope, you'll get an immediate `TypeError`:
+
+```
+TypeError: Check 'my-check' (scope=prose) has signature
+('line', 'num', 'state', 'cfg', 'file_result') but expected
+('line', 'line_num', 'state', 'cfg', 'file_result') matching
+LineCheck(line, line_num, state, cfg, file_result)
+```
+
+The expected signatures per scope:
+
+| Scope                  | Parameters |
+|------------------------|------------|
+| `prose`                | `(line, line_num, state, cfg, file_result)` |
+| `code_block_content`   | `(line, line_num, state, cfg, file_result)` |
+| `code_block_boundary`  | `(line, line_num, state, cfg, file_result)` |
+| `structural`           | `(filepath, lines, cfg, file_result)` |
+
+---
+
+## Testing your check
+
+Run against a single file:
+
+```bash
+python3 scripts/review-docs.py path/to/file.adoc --only=my-check
+```
+
+Run against all files:
+
+```bash
+python3 scripts/review-docs.py --all --only=my-check
+```
+
+Get JSON output for inspection:
+
+```bash
+python3 scripts/review-docs.py --all --only=my-check --format json
+```
+
+List all registered checks (confirm yours appears):
+
+```bash
+python3 scripts/review-docs.py --list-checks
+```
+
+---
+
+## Checklist
+
+- [ ] Function decorated with `@register_check(name, severity, scope)`
+- [ ] Parameter names match the expected signature for your scope
+- [ ] `check_name` in `add_finding()` matches the `name` in the decorator
+- [ ] Module imported in `checks/__init__.py` (if new module)
+- [ ] Entry added to `.review-docs.conf` (commented out)
+- [ ] Tested with `--only=my-check` against representative files
+- [ ] No false positives on `--all`

--- a/scripts/review_docs/checks/code_blocks.py
+++ b/scripts/review_docs/checks/code_blocks.py
@@ -3,7 +3,7 @@
 import re
 
 from ..config import Config
-from ..models import FileResult
+from ..models import FileResult, ParseState
 from ..registry import register_check
 
 
@@ -11,20 +11,20 @@ from ..registry import register_check
 def check_code_block_language(
     line: str,
     line_num: int,
-    state: dict,
+    state: ParseState,
     cfg: Config,
     file_result: FileResult,
 ) -> None:
     """Check that a code block opening has a ``[source,language]`` specifier.
 
     Boundary checks are called when a ``----`` delimiter is encountered.
-    ``state["boundary_direction"]`` is ``"open"`` or ``"close"``.
-    ``state["prev_line"]`` contains the line immediately before the delimiter.
+    ``state.boundary_direction`` is ``"open"`` or ``"close"``.
+    ``state.prev_line`` contains the line immediately before the delimiter.
     """
-    if state.get("boundary_direction") != "open":
+    if state.boundary_direction != "open":
         return
 
-    prev = state.get("prev_line", "")
+    prev = state.prev_line
     m = re.match(r"^\[source,?([a-zA-Z0-9_-]*)\]", prev) or re.match(
         r"^\[source,?([a-zA-Z0-9_-]*),.*\]", prev
     )
@@ -45,12 +45,12 @@ def check_code_block_language(
 def check_yaml_null_timestamps(
     line: str,
     line_num: int,
-    state: dict,
+    state: ParseState,
     cfg: Config,
     file_result: FileResult,
 ) -> None:
     """Check for creationTimestamp: null in YAML blocks."""
-    if state.get("code_block_lang") == "yaml" and re.search(
+    if state.code_block_lang == "yaml" and re.search(
         r"creationTimestamp:\s*null", line
     ):
         file_result.add_finding(
@@ -65,12 +65,12 @@ def check_yaml_null_timestamps(
 def check_yaml_flow_syntax(
     line: str,
     line_num: int,
-    state: dict,
+    state: ParseState,
     cfg: Config,
     file_result: FileResult,
 ) -> None:
     """Check for inline YAML flow syntax ({} or []) in YAML blocks."""
-    if state.get("code_block_lang") != "yaml":
+    if state.code_block_lang != "yaml":
         return
 
     if re.search(r".*:\s*\{.*\}", line) or re.search(r".*:\s*\[.*\]", line):

--- a/scripts/review_docs/checks/prose.py
+++ b/scripts/review_docs/checks/prose.py
@@ -3,7 +3,7 @@
 import re
 
 from ..config import Config
-from ..models import FileResult
+from ..models import FileResult, ParseState
 from ..registry import register_check
 
 # Admonition keywords (used by the admonition-capitalization check)
@@ -14,7 +14,7 @@ ADMONITIONS = r"NOTE|WARNING|TIP|IMPORTANT|CAUTION"
 def check_heading_hierarchy(
     line: str,
     line_num: int,
-    state: dict,
+    state: ParseState,
     cfg: Config,
     file_result: FileResult,
 ) -> None:
@@ -28,15 +28,15 @@ def check_heading_hierarchy(
 
     # Count H1s
     if level == 1:
-        state["h1_count"] = state.get("h1_count", 0) + 1
-        if state["h1_count"] > 1:
+        state.h1_count += 1
+        if state.h1_count > 1:
             file_result.add_finding(
                 cfg,
                 "heading-hierarchy",
                 line_num,
                 f"line {line_num}: Multiple H1 headings found (should have only one)",
             )
-        if state.get("first_heading_found", False):
+        if state.first_heading_found:
             file_result.add_finding(
                 cfg,
                 "heading-hierarchy",
@@ -44,12 +44,11 @@ def check_heading_hierarchy(
                 f"line {line_num}: H1 must be the first heading in the file",
             )
 
-    state["first_heading_found"] = True
+    state.first_heading_found = True
 
     # Check for skipped levels
-    heading_levels = state.get("heading_levels", [])
-    if heading_levels:
-        prev_level = heading_levels[-1]
+    if state.heading_levels:
+        prev_level = state.heading_levels[-1]
         if level > prev_level + 1:
             file_result.add_finding(
                 cfg,
@@ -58,20 +57,19 @@ def check_heading_hierarchy(
                 f"line {line_num}: Heading level skipped (previous: {prev_level}, current: {level})",
             )
 
-    heading_levels.append(level)
-    state["heading_levels"] = heading_levels
+    state.heading_levels.append(level)
 
 
 @register_check("heading-blank-line", "warning", "prose")
 def check_heading_blank_line(
     line: str,
     line_num: int,
-    state: dict,
+    state: ParseState,
     cfg: Config,
     file_result: FileResult,
 ) -> None:
     """Check that headings are followed by a blank line."""
-    prev_line = state.get("prev_line", "")
+    prev_line = state.prev_line
 
     # Check if previous line was a heading and this line is not blank
     if re.match(r"^(=+)\s+(.+)$", prev_line):
@@ -88,7 +86,7 @@ def check_heading_blank_line(
 def check_trailing_whitespace(
     line: str,
     line_num: int,
-    state: dict,
+    state: ParseState,
     cfg: Config,
     file_result: FileResult,
 ) -> None:
@@ -106,7 +104,7 @@ def check_trailing_whitespace(
 def check_bare_urls(
     line: str,
     line_num: int,
-    state: dict,
+    state: ParseState,
     cfg: Config,
     file_result: FileResult,
 ) -> None:
@@ -128,7 +126,7 @@ def check_bare_urls(
 def check_external_link_target(
     line: str,
     line_num: int,
-    state: dict,
+    state: ParseState,
     cfg: Config,
     file_result: FileResult,
 ) -> None:
@@ -149,7 +147,7 @@ def check_external_link_target(
 def check_image_alt_text(
     line: str,
     line_num: int,
-    state: dict,
+    state: ParseState,
     cfg: Config,
     file_result: FileResult,
 ) -> None:
@@ -168,7 +166,7 @@ def check_image_alt_text(
 def check_product_names(
     line: str,
     line_num: int,
-    state: dict,
+    state: ParseState,
     cfg: Config,
     file_result: FileResult,
 ) -> None:
@@ -187,7 +185,7 @@ def check_product_names(
 def check_banned_terms(
     line: str,
     line_num: int,
-    state: dict,
+    state: ParseState,
     cfg: Config,
     file_result: FileResult,
 ) -> None:
@@ -209,7 +207,7 @@ def check_banned_terms(
 def check_admonition_capitalization(
     line: str,
     line_num: int,
-    state: dict,
+    state: ParseState,
     cfg: Config,
     file_result: FileResult,
 ) -> None:

--- a/scripts/review_docs/engine.py
+++ b/scripts/review_docs/engine.py
@@ -31,6 +31,32 @@ class BuildResult:
     findings: List[Finding] = field(default_factory=list)
 
 
+# ── Block delimiter mapping ──────────────────────────────────────────────────
+
+# Maps AsciiDoc block delimiter patterns to semantic block type names.
+# The engine pushes/pops these on ``ParseState.block_stack`` as delimiters
+# are encountered.  Code blocks (``----`` / ``"code_block"``) are also
+# tracked on block_stack but handled in a dedicated branch because they
+# carry extra metadata (language, boundary direction) and dispatch to
+# their own check scopes (code_block_content, code_block_boundary).
+# Note: ``--`` is a legitimate 2-character AsciiDoc open block delimiter.
+# False positives are unlikely because:
+#   1. Code blocks (``----``, 4+ dashes) are caught by a dedicated branch
+#      *before* ``_check_block_boundary`` is called.
+#   2. The match is exact (``stripped == delimiter``), so em-dash
+#      replacements or ``---`` / ``----`` lines don't trigger it.
+#   3. A bare ``--`` line outside of intentional block markup is
+#      extremely rare in practice.
+_BLOCK_DELIMITERS = {
+    "|===": "table",
+    "====": "admonition",
+    "****": "sidebar",
+    "++++": "passthrough",
+    "....": "literal",
+    "--": "open",
+}
+
+
 # ── Internal helpers ──────────────────────────────────────────────────────────
 
 
@@ -56,6 +82,36 @@ def _compute_word_count(lines: List[str]) -> int:
             word_count += len(line.split())
 
     return word_count
+
+
+def _check_block_boundary(line: str, state: ParseState) -> bool:
+    """Check if *line* is a non-code-block delimiter and update *state*.
+
+    Returns ``True`` if the line was consumed as a block delimiter
+    (callers should skip further processing).
+
+    AsciiDoc block delimiters are toggle-style: the same delimiter string
+    opens and closes a block.  When the top of the stack matches, we pop
+    (close).  When it doesn't, we scan deeper — if the block type exists
+    anywhere on the stack we treat the line as a close for a mismatched
+    nesting (popping back to and including that entry), otherwise we push
+    (open).
+    """
+    stripped = line.rstrip()
+    for delimiter, block_type in _BLOCK_DELIMITERS.items():
+        if stripped == delimiter:
+            if state.block_stack and state.block_stack[-1] == block_type:
+                # Clean close — top of stack matches.
+                state.block_stack.pop()
+            elif block_type in state.block_stack:
+                # Mismatched nesting — pop back to the matching open.
+                idx = len(state.block_stack) - 1 - state.block_stack[::-1].index(block_type)
+                state.block_stack = state.block_stack[:idx]
+            else:
+                # New open.
+                state.block_stack.append(block_type)
+            return True
+    return False
 
 
 # ── Public API ────────────────────────────────────────────────────────────────
@@ -103,7 +159,7 @@ def review_file(filepath: str, cfg: Config) -> FileResult:
         # Track code block boundaries
         if re.match(r"^----", line):
             if not state.in_code_block:
-                state.in_code_block = True
+                state.block_stack.append("code_block")
                 state.code_block_start_line = line_num
                 state.boundary_direction = "open"
 
@@ -114,7 +170,7 @@ def review_file(filepath: str, cfg: Config) -> FileResult:
                 ) or re.match(r"^\[source,?([a-zA-Z0-9_-]*),.*\]", prev)
                 state.code_block_lang = m.group(1) if m else ""
             else:
-                state.in_code_block = False
+                state.block_stack.pop()
                 state.code_block_lang = ""
                 state.boundary_direction = "close"
 
@@ -130,6 +186,11 @@ def review_file(filepath: str, cfg: Config) -> FileResult:
             for check_def in code_block_checks:
                 check_def.func(line, line_num, state, cfg, file_result)
 
+            state.prev_line = line
+            continue
+
+        # Track non-code-block delimiters (tables, admonitions, etc.)
+        if _check_block_boundary(line, state):
             state.prev_line = line
             continue
 

--- a/scripts/review_docs/engine.py
+++ b/scripts/review_docs/engine.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import List
 
 from .config import Config
-from .models import FileResult, Finding
+from .models import FileResult, Finding, ParseState
 from .registry import CHECKS
 
 # Ensure all checks are registered before the engine runs.
@@ -92,60 +92,52 @@ def review_file(filepath: str, cfg: Config) -> FileResult:
     structural_checks = _get_enabled_checks(cfg, "structural")
 
     # Line-by-line state machine
-    state: dict = {
-        "in_code_block": False,
-        "code_block_lang": "",
-        "code_block_start_line": 0,
-        "prev_line": "",
-        "heading_levels": [],
-        "first_heading_found": False,
-        "h1_count": 0,
-    }
+    state = ParseState()
 
     for line_num, line in enumerate(lines, 1):
         # Skip comment lines for prose checks
         if re.match(r"^//", line):
-            state["prev_line"] = line
+            state.prev_line = line
             continue
 
         # Track code block boundaries
         if re.match(r"^----", line):
-            if not state["in_code_block"]:
-                state["in_code_block"] = True
-                state["code_block_start_line"] = line_num
-                state["boundary_direction"] = "open"
+            if not state.in_code_block:
+                state.in_code_block = True
+                state.code_block_start_line = line_num
+                state.boundary_direction = "open"
 
-                prev = state["prev_line"]
+                prev = state.prev_line
                 # Detect language specifier in previous line
                 m = re.match(
                     r"^\[source,?([a-zA-Z0-9_-]*)\]", prev
                 ) or re.match(r"^\[source,?([a-zA-Z0-9_-]*),.*\]", prev)
-                state["code_block_lang"] = m.group(1) if m else ""
+                state.code_block_lang = m.group(1) if m else ""
             else:
-                state["in_code_block"] = False
-                state["code_block_lang"] = ""
-                state["boundary_direction"] = "close"
+                state.in_code_block = False
+                state.code_block_lang = ""
+                state.boundary_direction = "close"
 
             # Run boundary checks
             for check_def in boundary_checks:
                 check_def.func(line, line_num, state, cfg, file_result)
 
-            state["prev_line"] = line
+            state.prev_line = line
             continue
 
         # Inside code block: run code block content checks
-        if state["in_code_block"]:
+        if state.in_code_block:
             for check_def in code_block_checks:
                 check_def.func(line, line_num, state, cfg, file_result)
 
-            state["prev_line"] = line
+            state.prev_line = line
             continue
 
         # Outside code block: run prose checks
         for check_def in prose_checks:
             check_def.func(line, line_num, state, cfg, file_result)
 
-        state["prev_line"] = line
+        state.prev_line = line
 
     # Run structural checks
     for check_def in structural_checks:

--- a/scripts/review_docs/models.py
+++ b/scripts/review_docs/models.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Protocol
 
 if TYPE_CHECKING:
     from .config import Config
@@ -121,6 +122,84 @@ class ReviewResult:
     files: List[FileResult] = field(default_factory=list)
     total_errors: int = 0
     total_warnings: int = 0
+
+
+# ── Check type protocols ──────────────────────────────────────────────────────
+
+# These protocols define the expected call signatures for each check scope.
+# They are used for validation at registration time.
+
+
+class LineCheck(Protocol):
+    """Signature for prose, code_block_content, and code_block_boundary checks."""
+
+    def __call__(
+        self,
+        line: str,
+        line_num: int,
+        state: ParseState,
+        cfg: Config,
+        file_result: FileResult,
+    ) -> None: ...
+
+
+class StructuralCheck(Protocol):
+    """Signature for structural checks (operate on full file content)."""
+
+    def __call__(
+        self,
+        filepath: str,
+        lines: List[str],
+        cfg: Config,
+        file_result: FileResult,
+    ) -> None: ...
+
+
+# Maps scope name -> (expected parameter names, protocol description)
+SCOPE_SIGNATURES: Dict[str, tuple[tuple[str, ...], str]] = {
+    "prose": (
+        ("line", "line_num", "state", "cfg", "file_result"),
+        "LineCheck(line, line_num, state, cfg, file_result)",
+    ),
+    "code_block_content": (
+        ("line", "line_num", "state", "cfg", "file_result"),
+        "LineCheck(line, line_num, state, cfg, file_result)",
+    ),
+    "code_block_boundary": (
+        ("line", "line_num", "state", "cfg", "file_result"),
+        "LineCheck(line, line_num, state, cfg, file_result)",
+    ),
+    "structural": (
+        ("filepath", "lines", "cfg", "file_result"),
+        "StructuralCheck(filepath, lines, cfg, file_result)",
+    ),
+}
+
+
+def validate_check_signature(func: Callable, scope: str, name: str) -> None:
+    """Validate that *func*'s parameters match the expected signature for *scope*.
+
+    Raises ``TypeError`` at registration time if there is a mismatch.
+    """
+    if scope not in SCOPE_SIGNATURES:
+        raise ValueError(
+            f"Check '{name}': unknown scope '{scope}'. "
+            f"Valid scopes: {', '.join(SCOPE_SIGNATURES)}"
+        )
+
+    expected_params, description = SCOPE_SIGNATURES[scope]
+    sig = inspect.signature(func)
+    actual_params = tuple(sig.parameters.keys())
+
+    if actual_params != expected_params:
+        raise TypeError(
+            f"Check '{name}' (scope={scope}) has signature "
+            f"{actual_params} but expected {expected_params} "
+            f"matching {description}"
+        )
+
+
+# ── Check definition ─────────────────────────────────────────────────────────
 
 
 @dataclass

--- a/scripts/review_docs/models.py
+++ b/scripts/review_docs/models.py
@@ -25,8 +25,9 @@ class ParseState:
     # ── Previous line (set by engine at end of each iteration) ────────
     prev_line: str = ""
 
-    # ── Code-block tracking (managed by engine) ──────────────────────
-    in_code_block: bool = False
+    # ── Code-block metadata (managed by engine) ────────────────────────
+    # Code blocks are also tracked on ``block_stack`` as ``"code_block"``.
+    # These attributes carry code-block-specific metadata.
     code_block_lang: str = ""
     code_block_start_line: int = 0
     boundary_direction: str = ""  # "open" or "close", set at ---- boundary
@@ -38,6 +39,22 @@ class ParseState:
 
     # ── List context (managed by list-blank-line check) ──────────────
     in_list: bool = False
+
+    # ── Block context (managed by engine) ────────────────────────────
+    # Stack of currently-open block types.  The engine pushes/pops as
+    # block delimiters are encountered — including ``----`` code blocks
+    # (as ``"code_block"``), ``|===``, ``====``, ``****``, ``++++``,
+    # ``--``, and ``....``.  Checks can query membership, e.g.
+    # ``state.in_block("table")`` or ``state.in_block("code_block")``.
+    block_stack: List[str] = field(default_factory=list)
+
+    @property
+    def in_code_block(self) -> bool:
+        """Whether we are currently inside a ``----`` code block.
+
+        Convenience property — equivalent to ``self.in_block("code_block")``.
+        """
+        return self.in_block("code_block")
 
     # ── Per-check private state ──────────────────────────────────────
     _check_state: Dict[str, Dict[str, Any]] = field(
@@ -52,6 +69,10 @@ class ParseState:
         if check_name not in self._check_state:
             self._check_state[check_name] = {}
         return self._check_state[check_name]
+
+    def in_block(self, block_type: str) -> bool:
+        """Return ``True`` if currently inside a block of the given type."""
+        return block_type in self.block_stack
 
 
 # ── Findings and results ──────────────────────────────────────────────────────

--- a/scripts/review_docs/models.py
+++ b/scripts/review_docs/models.py
@@ -3,10 +3,58 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Callable, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 if TYPE_CHECKING:
     from .config import Config
+
+
+# ── Parse state ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ParseState:
+    """Line-by-line parser state maintained by the engine.
+
+    This replaces the untyped ``state: dict`` that was shared between
+    the engine and check functions.  Checks read/write named attributes
+    instead of opaque string keys.  Per-check private state is available
+    via :meth:`check_state`.
+    """
+
+    # ── Previous line (set by engine at end of each iteration) ────────
+    prev_line: str = ""
+
+    # ── Code-block tracking (managed by engine) ──────────────────────
+    in_code_block: bool = False
+    code_block_lang: str = ""
+    code_block_start_line: int = 0
+    boundary_direction: str = ""  # "open" or "close", set at ---- boundary
+
+    # ── Heading tracking (managed by heading-hierarchy check) ─────────
+    heading_levels: List[int] = field(default_factory=list)
+    first_heading_found: bool = False
+    h1_count: int = 0
+
+    # ── List context (managed by list-blank-line check) ──────────────
+    in_list: bool = False
+
+    # ── Per-check private state ──────────────────────────────────────
+    _check_state: Dict[str, Dict[str, Any]] = field(
+        default_factory=dict, repr=False
+    )
+
+    def check_state(self, check_name: str) -> Dict[str, Any]:
+        """Return a private state dict for the named check.
+
+        Created lazily on first access.
+        """
+        if check_name not in self._check_state:
+            self._check_state[check_name] = {}
+        return self._check_state[check_name]
+
+
+# ── Findings and results ──────────────────────────────────────────────────────
 
 
 @dataclass

--- a/scripts/review_docs/registry.py
+++ b/scripts/review_docs/registry.py
@@ -7,7 +7,7 @@ happens automatically when the package is first imported.
 
 from typing import Callable, Dict
 
-from .models import CheckDef
+from .models import CheckDef, validate_check_signature
 
 # Global registry populated by @register_check decorators.
 CHECKS: Dict[str, CheckDef] = {}
@@ -15,6 +15,10 @@ CHECKS: Dict[str, CheckDef] = {}
 
 def register_check(name: str, severity: str, scope: str):
     """Decorator that registers a check function in the global CHECKS dict.
+
+    The function's signature is validated against the expected parameters
+    for the given *scope* at registration time.  A ``TypeError`` is raised
+    immediately if the signature does not match.
 
     Parameters
     ----------
@@ -28,6 +32,7 @@ def register_check(name: str, severity: str, scope: str):
     """
 
     def decorator(func: Callable) -> Callable:
+        validate_check_signature(func, scope, name)
         CHECKS[name] = CheckDef(
             name=name, default_severity=severity, scope=scope, func=func
         )


### PR DESCRIPTION
## Description

<!-- Provide a brief description of your changes -->
Some more refactors on the review-docs codebase to allow for easier extension (e.g. with the list-blank-line check which is in progress). Also include a small markdown guide for modifying or adding new checks.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [ ] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

Part of #336.

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [ ] Technical details verified against official documentation
- [ ] Use Professional language

### Testing & Verification
- [ ] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [ ] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [ ] All internal links (xrefs) are working
- [ ] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

### Build & Preview
- [ ] `npm run build` completes without errors
- [ ] Local preview verified (`npm run serve`)
- [ ] No broken xref warnings in build output
- [ ] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made

<!-- Provide a bullet-point list of changes -->

- Use a `ParseState` dataclass instead of a plain dict in checks functions
- Track block contexts in engine rather than individual checks
- Validate checks functions signatures before running
- Add markdown guide for checks authors

## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

