### PR TITLE
Fix broken AsciiDoc lists in doc modules

### DIFF
--- a/modules/getting-started/pages/create-vm-cli-yaml.adoc
+++ b/modules/getting-started/pages/create-vm-cli-yaml.adoc
@@ -108,6 +108,7 @@ virtctl create vm --name=my-rhel-vm \
 ----
 
 This command:
+
 - Creates a VM named `my-rhel-vm`
 - Imports from the RHEL 9 DataSource as the boot volume
 - Sets memory to 2Gi (CPU allocation is handled via instancetypes or manual manifest editing)
@@ -276,6 +277,7 @@ virtctl console vm-minimal -n demo
 ----
 
 Log in with the credentials from cloud-init:
+
 - Username: `fedora`
 - Password: `fedora123`
 
@@ -635,6 +637,7 @@ oc describe vmi <vm-name> -n demo
 ----
 
 Common issues:
+
 - DataVolume provisioning failed (check `oc get dv`)
 - Insufficient cluster resources (check node capacity)
 - Invalid cloud-init syntax (check pod logs)

--- a/modules/performance/pages/vm-monitoring-metrics.adoc
+++ b/modules/performance/pages/vm-monitoring-metrics.adoc
@@ -276,6 +276,7 @@ If your organization requires advanced dashboard features, Grafana can be instal
 NOTE: This requires cluster admin permissions and additional setup beyond this tutorial scope.
 
 **Installation overview:**
+
 * Install Grafana Operator from OperatorHub
 * Configure Prometheus data source
 * Import or create VM monitoring dashboards
@@ -512,6 +513,7 @@ Download and install the virtio-win drivers package which includes the QEMU gues
 **Symptom**: Empty charts or "No data available"
 
 **Solutions**:
+
 * Wait 2-3 minutes for metrics collection to begin
 * Verify the VM is in Running state: `oc get vm`
 * Check that cluster monitoring is enabled in OpenShift
@@ -522,6 +524,7 @@ Download and install the virtio-win drivers package which includes the QEMU gues
 **Symptom**: Limited guest OS information in web console
 
 **Solutions**:
+
 * Verify guest agent installation: `systemctl status qemu-guest-agent`
 * Restart the guest agent: `systemctl restart qemu-guest-agent`
 * Check VM template includes guest agent installation
@@ -532,6 +535,7 @@ Download and install the virtio-win drivers package which includes the QEMU gues
 **Symptom**: Monitoring stack consuming excessive cluster resources
 
 **Solutions**:
+
 * Adjust Prometheus retention period if storage is limited
 * Reduce scrape intervals for non-critical metrics
 * Use recording rules for frequently-queried complex expressions

--- a/modules/vm-configuration/pages/remote-access-linux-troubleshooting.adoc
+++ b/modules/vm-configuration/pages/remote-access-linux-troubleshooting.adoc
@@ -84,6 +84,7 @@ oc get pods -n my-namespace -l kubevirt.io/domain=my-vm
 ----
 
 **Common Causes**:
+
 - VM is not running
 - VMI not created
 - virt-launcher pod not running
@@ -133,6 +134,7 @@ Console connects but shows blank screen or no prompt.
 ----
 
 **Common Causes**:
+
 - VM still booting
 - Serial console not configured in VM
 - systemd-getty not running on ttyS0
@@ -162,6 +164,7 @@ virtctl console my-vm -n my-namespace
 Login prompt appears but credentials do not work.
 
 **Common Causes**:
+
 - Wrong username/password
 - Cloud-init SSH-only access configured
 - Root login disabled
@@ -207,10 +210,12 @@ oc get vm my-vm -n my-namespace -o yaml | grep -A 10 "devices:"
 ----
 
 **Common Causes**:
+
 - Graphics device disabled via `autoattachGraphicsDevice: false`
 - VM spec explicitly excludes graphics device
 
 **Solutions**:
+
 . Ensure graphics device is enabled (it is enabled by default in OpenShift Virtualization). If explicitly disabled, remove the `autoattachGraphicsDevice: false` setting or set it to `true`.
 
 === Issue: VNC Viewer Cannot Connect
@@ -230,6 +235,7 @@ netstat -tuln | grep 5900
 ----
 
 **Common Causes**:
+
 - Firewall blocking VNC port
 - VNC viewer not installed or wrong viewer
 - Port conflict
@@ -255,6 +261,7 @@ brew install tiger-vnc
 VNC connects but shows blank or black screen.
 
 **Common Causes**:
+
 - VM still booting
 - No display manager running
 - VM is console-only (no GUI)
@@ -295,6 +302,7 @@ virtctl console my-vm -n my-namespace
 ----
 
 **Common Causes**:
+
 - SSH service not running in VM
 - No IP address assigned to VM
 - SSH not installed in VM
@@ -345,6 +353,7 @@ virtctl ssh --local-ssh-opts="-o PreferredAuthentications=password" fedora@my-vm
 ----
 
 **Common Causes**:
+
 - SSH public key not in VM's authorized_keys
 - Wrong username
 - SSH key passphrase required
@@ -377,6 +386,7 @@ chmod 600 ~/.ssh/authorized_keys
 Connection takes 30+ seconds to establish.
 
 **Common Causes**:
+
 - DNS reverse lookup timeout
 - GSSAPI authentication attempt
 
@@ -412,6 +422,7 @@ oc get svc my-vm-ssh -n my-namespace -o jsonpath='{.spec.ports[0].nodePort}'
 ----
 
 **Common Causes**:
+
 - Service not created
 - Wrong NodePort number
 - VM pod not running or not ready
@@ -468,6 +479,7 @@ oc describe svc my-vm-ssh -n my-namespace
 ----
 
 **Common Causes**:
+
 - Service selector matches multiple VMs
 - Service selector does not match any VM
 
@@ -530,6 +542,7 @@ oc describe svc my-vm-ssh -n my-namespace
 ----
 
 **Common Causes**:
+
 - No LoadBalancer provider configured (MetalLB, cloud provider)
 - LoadBalancer quota exhausted
 - LoadBalancer configuration error
@@ -565,6 +578,7 @@ oc run test-curl --image=curlimages/curl --rm -it --restart=Never -- curl -v tel
 ----
 
 **Common Causes**:
+
 - LoadBalancer IP not routable
 - Firewall blocking traffic
 - LoadBalancer misconfiguration
@@ -599,6 +613,7 @@ lsof -i :2222
 ----
 
 **Common Causes**:
+
 - Local port already in use
 - VMI not running
 - Network policy blocking port-forward
@@ -647,6 +662,7 @@ ss -tuln | grep :22
 ----
 
 **Common Causes**:
+
 - SSH not running in VM
 - SSH listening on different port
 - VM does not have SSH installed
@@ -682,6 +698,7 @@ sudo cat /etc/ssh/sshd_config | grep ^Port
 Port forward works but drops connection after few minutes.
 
 **Common Causes**:
+
 - Idle timeout
 - API server connection timeout
 - Network instability
@@ -729,6 +746,7 @@ oc get vm my-vm -n my-namespace -o jsonpath='{.spec.template.spec.networks}' | j
 ----
 
 **Common Causes**:
+
 - NetworkAttachmentDefinition not configured
 - VM does not have secondary network interface
 - Secondary network IP not configured
@@ -791,6 +809,7 @@ oc get vmi my-vm -n my-namespace -o jsonpath='{.status.interfaces}' | jq
 ----
 
 **Common Causes**:
+
 - NAD does not exist in same namespace
 - VM spec missing secondary network interface
 - Multus CNI not working

--- a/modules/vm-lifecycle/pages/custom-golden-images.adoc
+++ b/modules/vm-lifecycle/pages/custom-golden-images.adoc
@@ -553,6 +553,7 @@ To create new versions of your golden image:
 . Update VM deployments to reference the new version
 
 Example DataSource naming:
+
 - `fedora-nginx-golden-v1`
 - `fedora-nginx-golden-v2`
 - `fedora-nginx-golden-2025-10`


### PR DESCRIPTION
## Description

<!-- Provide a brief description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [x] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue
None

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [ ] Technical details verified against official documentation
- [ ] Use Professional language

### Testing & Verification
- [ ] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [x] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [ ] All internal links (xrefs) are working
- [ ] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

### Build & Preview
- [x] `npm run build` completes without errors
- [x] Local preview verified (`npm run serve`)
- [ ] No broken xref warnings in build output
- [ ] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made

<!-- Provide a bullet-point list of changes -->

- Add additional whitespace where needed for lists to render properly
- These occurrences were identified using the new doc review check added in #339

## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

