### PR TITLE
review_docs: check prose text only in product-names and banned-terms checks

### DIFF
--- a/scripts/review_docs/checks/prose.py
+++ b/scripts/review_docs/checks/prose.py
@@ -10,6 +10,44 @@ from ..registry import register_check
 ADMONITIONS = r"NOTE|WARNING|TIP|IMPORTANT|CAUTION"
 
 
+def _extract_prose_text(line: str) -> str:
+    """Remove non-prose constructs from line, leaving only user-facing text.
+
+    Strips URLs, xref/image/include paths, attribute definitions/references,
+    source block specifiers, and inline code so checks like product-names
+    and banned-terms only examine prose intended for readers.
+    """
+    # Skip attribute definition lines entirely (e.g., :navtitle: ...)
+    if re.match(r"^:[a-zA-Z][^:]*:", line):
+        return ""
+
+    # Skip source block attribute lines (e.g., [source,yaml])
+    if re.match(r"^\[source", line):
+        return ""
+
+    text = line
+
+    # Remove inline code (backticks)
+    text = re.sub(r"`[^`]+`", "", text)
+
+    # Remove URLs (standalone or in link macros)
+    text = re.sub(r"https?://[^\s\[\]]+", "", text)
+
+    # Remove xref targets (keep display text in brackets)
+    text = re.sub(r"xref:[^\[]+", "", text)
+
+    # Remove image paths (keep alt text in brackets)
+    text = re.sub(r"image::[^\[]+", "", text)
+
+    # Remove include directives entirely (no user-facing text)
+    text = re.sub(r"include::[^\[]+\[[^\]]*\]", "", text)
+
+    # Remove attribute references
+    text = re.sub(r"\{[^}]+\}", "", text)
+
+    return text
+
+
 @register_check("heading-hierarchy", "error", "prose")
 def check_heading_hierarchy(
     line: str,
@@ -170,9 +208,14 @@ def check_product_names(
     cfg: Config,
     file_result: FileResult,
 ) -> None:
-    """Check product name capitalization."""
+    """Check product name capitalization in user-facing text."""
+    # Skip inside literal or passthrough blocks (code-like content)
+    if state.in_block("literal") or state.in_block("passthrough"):
+        return
+
+    prose_text = _extract_prose_text(line)
     for wrong, correct in cfg.product_names.items():
-        if wrong in line:
+        if wrong in prose_text:
             file_result.add_finding(
                 cfg,
                 "product-names",
@@ -189,11 +232,16 @@ def check_banned_terms(
     cfg: Config,
     file_result: FileResult,
 ) -> None:
-    """Check banned terminology."""
+    """Check banned terminology in user-facing text."""
+    # Skip inside literal or passthrough blocks (code-like content)
+    if state.in_block("literal") or state.in_block("passthrough"):
+        return
+
+    prose_text = _extract_prose_text(line)
     for banned, replacement in cfg.banned_terms.items():
         # Use word boundaries to avoid false positives
         if re.search(
-            rf"(?:^|[^a-zA-Z0-9]){re.escape(banned)}(?:[^a-zA-Z0-9]|$)", line
+            rf"(?:^|[^a-zA-Z0-9]){re.escape(banned)}(?:[^a-zA-Z0-9]|$)", prose_text
         ):
             file_result.add_finding(
                 cfg,


### PR DESCRIPTION
## Description

Avoid flagging occurrences in code blocks, URLs, etc. where things all tend to be lowercase anyways.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [ ] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

Part of #336.

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [ ] Technical details verified against official documentation
- [ ] Use Professional language

### Testing & Verification
- [ ] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [ ] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [ ] All internal links (xrefs) are working
- [ ] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

### Build & Preview
- [ ] `npm run build` completes without errors
- [ ] Local preview verified (`npm run serve`)
- [ ] No broken xref warnings in build output
- [ ] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made

<!-- Provide a bullet-point list of changes -->

- Add a helper function for removing non-prose constructs (URLs, xref/image/include paths, attribute definitions and references, inline code)
- Adjust `product-names` and `banned-terms` checks to preprocess lines using the helper function
- Adjust `product-names` and `banned-terms` checks to be block aware (avoid flagging occurrences in e.g. a YAML block)

## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

