### PR TITLE
Clarify networkDataSecretRef usage in cloud-init

### DIFF
--- a/modules/getting-started/pages/cloud-init-fundamentals.adoc
+++ b/modules/getting-started/pages/cloud-init-fundamentals.adoc
@@ -420,6 +420,8 @@ volumes:
 ----
 <1> KubeVirt reads the `userdata` key from the Secret and delivers it as the cloud-init userData.
 
+For networkData, use `networkDataSecretRef` instead of `secretRef` for referencing the Secret containing the network configuration.
+
 == Verifying Cloud-init Ran
 
 After your VM boots, verify that cloud-init processed the configuration successfully.

--- a/modules/getting-started/pages/cloud-init-fundamentals.adoc
+++ b/modules/getting-started/pages/cloud-init-fundamentals.adoc
@@ -421,7 +421,7 @@ volumes:
 <1> KubeVirt reads the `userdata` key from the Secret and delivers it as the cloud-init userData.
 
 For networkData, use `networkDataSecretRef` instead of `secretRef` for referencing the Secret containing the network configuration.
-
+link:https://kubevirt.io/user-guide/user_workloads/startup_scripts/#cloud-init-network-config-as-k8s-secret[Cloud-init network configuration,window=_blank]
 == Verifying Cloud-init Ran
 
 After your VM boots, verify that cloud-init processed the configuration successfully.

--- a/modules/getting-started/pages/cloud-init-fundamentals.adoc
+++ b/modules/getting-started/pages/cloud-init-fundamentals.adoc
@@ -421,7 +421,21 @@ volumes:
 <1> KubeVirt reads the `userdata` key from the Secret and delivers it as the cloud-init userData.
 
 For networkData, use `networkDataSecretRef` instead of `secretRef` for referencing the Secret containing the network configuration.
+
 link:https://kubevirt.io/user-guide/user_workloads/startup_scripts/#cloud-init-network-config-as-k8s-secret[Cloud-init network configuration,window=_blank]
+
+Example:
+[source, yaml]
+----
+volumes:
+  - cloudInitNoCloud:
+      secretRef:
+        name: my-vm-userdata
+      networkDataSecretRef:
+        name: my-vm-networkdata
+    name: cloudinitdisk
+----
+
 == Verifying Cloud-init Ran
 
 After your VM boots, verify that cloud-init processed the configuration successfully.


### PR DESCRIPTION
Updated cloud-init documentation to specify using networkDataSecretRef for network configuration.

## Description

Add the secret reference for networkData

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [ ] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [x ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [ x] Technical details verified against official documentation
- [ ] Use Professional language

https://kubevirt.io/user-guide/user_workloads/startup_scripts/#cloud-init-network-config-as-k8s-secret

### Content Quality
- [ x] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [ ] All internal links (xrefs) are working
- [ ] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

## Changes Made

- one sentence added.

- 
- 
- 
## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

