### PR TITLE
Fix incorrect OpenShift product name usage

### DIFF
--- a/modules/getting-started/pages/install-openshift-virtualization.adoc
+++ b/modules/getting-started/pages/install-openshift-virtualization.adoc
@@ -54,7 +54,7 @@ OpenShift Cluster
       └─ Network Addons Op   — Multus CNI secondary networks
 ....
 
-=== Operators (openshift-cnv namespace)
+=== Operators (`openshift-cnv` namespace)
 
 The HyperConverged custom resource (CR) is the single entry point for the entire stack. Creating one `HyperConverged` CR triggers the deployment of four sub-operators:
 

--- a/modules/manifests/pages/index.adoc
+++ b/modules/manifests/pages/index.adoc
@@ -36,7 +36,7 @@ Manifests for LVM Storage Operator installation and configuration.
 
 |lvm-namespace
 |Namespace
-|Create openshift-lvm-storage namespace
+|Create `openshift-lvm-storage` namespace
 |xref:storage:lvm-operator.adoc[]
 |xref:storage:attachment$lvm-operator/lvm-namespace.yaml[YAML]
 

--- a/modules/storage/pages/creating-managing-storage-class.adoc
+++ b/modules/storage/pages/creating-managing-storage-class.adoc
@@ -153,7 +153,7 @@ spec:
   storageClassName: gp3-fast
 ----
 
-Openshift documentation: https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/storage/configuring-persistent-storage
+OpenShift documentation: https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/storage/configuring-persistent-storage
 
 == Common Troubleshooting Scenarios
 
@@ -170,7 +170,7 @@ Openshift documentation: https://docs.redhat.com/en/documentation/openshift_cont
 
 * **Issue 3:** "Provisioner not found" 
   ** Cause: The CSI driver specified in provisioner: is not installed or crashing.
-  ** Fix: Check the storage operator pods in the relevant namespace (e.g., openshift-cluster-csi-drivers).
+  ** Fix: Check the storage operator pods in the relevant namespace (e.g. `openshift-cluster-csi-drivers`).
 
 * **Issue 4:** Volume Resize Fails
   ** Cause: allowVolumeExpansion is set to false in the StorageClass.


### PR DESCRIPTION
## Description

<!-- Provide a brief description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [ ] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

<!-- Link to the issue this PR addresses -->
Part of #336

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [ ] Technical details verified against official documentation
- [ ] Use Professional language

### Testing & Verification
- [ ] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [ ] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [ ] All internal links (xrefs) are working
- [ ] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

### Build & Preview
- [x] `npm run build` completes without errors
- [x] Local preview verified (`npm run serve`)
- [x] No broken xref warnings in build output
- [ ] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made

<!-- Provide a bullet-point list of changes -->

- Fix occurrences of improper casing of "OpenShift"
- In usages describing a namespace/technical resource, enclose the name with backticks
## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

