### PR TITLE
Use instancetype and preference in networking tutorials

### DIFF
--- a/modules/networking/attachments/cloud-init-ip-configuration/fedora-dhcp-vm.yaml
+++ b/modules/networking/attachments/cloud-init-ip-configuration/fedora-dhcp-vm.yaml
@@ -4,6 +4,10 @@ metadata:
   name: fedora-dhcp-vm
   namespace: cloud-init-demo
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   dataVolumeTemplates:
     - apiVersion: cdi.kubevirt.io/v1beta1
       kind: DataVolume
@@ -25,24 +29,15 @@ spec:
         kubevirt.io/domain: fedora-dhcp-vm
     spec:
       domain:
-        cpu:
-          cores: 2
         devices:
           disks:
-            - disk:
-                bus: virtio
+            - disk: {}
               name: rootdisk
-            - disk:
-                bus: virtio
+            - disk: {}
               name: cloudinitdisk
           interfaces:
             - masquerade: {}
               name: default
-          rng: {}
-        machine:
-          type: pc-q35-rhel9.4.0
-        memory:
-          guest: 4Gi
       networks:
         - name: default
           pod: {}
@@ -55,6 +50,7 @@ spec:
               #cloud-config
               user: fedora
               password: fedora123
-              chpasswd: { expire: False }
+              chpasswd:
+                expire: false
               ssh_pwauth: True
           name: cloudinitdisk

--- a/modules/networking/attachments/cloud-init-ip-configuration/fedora-multi-network-vm.yaml
+++ b/modules/networking/attachments/cloud-init-ip-configuration/fedora-multi-network-vm.yaml
@@ -4,6 +4,10 @@ metadata:
   name: fedora-multi-vm
   namespace: cloud-init-demo
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   dataVolumeTemplates:
     - apiVersion: cdi.kubevirt.io/v1beta1
       kind: DataVolume
@@ -25,26 +29,17 @@ spec:
         kubevirt.io/domain: fedora-multi-vm
     spec:
       domain:
-        cpu:
-          cores: 2
         devices:
           disks:
-            - disk:
-                bus: virtio
+            - disk: {}
               name: rootdisk
-            - disk:
-                bus: virtio
+            - disk: {}
               name: cloudinitdisk
           interfaces:
             - masquerade: {}
               name: default
             - bridge: {}
               name: vlan-network
-          rng: {}
-        machine:
-          type: pc-q35-rhel9.4.0
-        memory:
-          guest: 4Gi
       networks:
         - name: default
           pod: {}
@@ -60,7 +55,8 @@ spec:
               #cloud-config
               user: fedora
               password: fedora123
-              chpasswd: { expire: False }
+              chpasswd:
+                expire: false
               ssh_pwauth: True
             networkData: |-
               version: 2

--- a/modules/networking/attachments/cloud-init-ip-configuration/fedora-vlan-static-ip-vm.yaml
+++ b/modules/networking/attachments/cloud-init-ip-configuration/fedora-vlan-static-ip-vm.yaml
@@ -4,6 +4,10 @@ metadata:
   name: fedora-vlan-vm
   namespace: cloud-init-demo
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   dataVolumeTemplates:
     - apiVersion: cdi.kubevirt.io/v1beta1
       kind: DataVolume
@@ -25,26 +29,17 @@ spec:
         kubevirt.io/domain: fedora-vlan-vm
     spec:
       domain:
-        cpu:
-          cores: 2
         devices:
           disks:
-            - disk:
-                bus: virtio
+            - disk: {}
               name: rootdisk
-            - disk:
-                bus: virtio
+            - disk: {}
               name: cloudinitdisk
           interfaces:
             - masquerade: {}
               name: default
             - bridge: {}
               name: vlan-100
-          rng: {}
-        machine:
-          type: pc-q35-rhel9.4.0
-        memory:
-          guest: 4Gi
       networks:
         - name: default
           pod: {}
@@ -60,7 +55,8 @@ spec:
               #cloud-config
               user: fedora
               password: fedora123
-              chpasswd: { expire: False }
+              chpasswd:
+                expire: false
               ssh_pwauth: True
               write_files:
                 - path: /var/www/html/index.html

--- a/modules/networking/attachments/dual-stack-vms/vm-dualstack-masquerade.yaml
+++ b/modules/networking/attachments/dual-stack-vms/vm-dualstack-masquerade.yaml
@@ -5,23 +5,22 @@ metadata:
   namespace: dualstack-demo
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
         app: dualstack-vm
     spec:
       domain:
-        resources:
-          requests:
-            memory: 2Gi
         devices:
           disks:
             - name: containerdisk
-              disk:
-                bus: virtio
+              disk: {}
             - name: cloudinitdisk
-              disk:
-                bus: virtio
+              disk: {}
           interfaces:
             - name: default
               masquerade: {}
@@ -50,5 +49,6 @@ spec:
               ethernets:
                 eth0:
                   dhcp4: true
-                  addresses: [ fd10:0:2::2/120 ]
+                  addresses:
+                    - fd10:0:2::2/120
                   gateway6: fd10:0:2::1

--- a/modules/networking/attachments/dual-stack-vms/vm-dualstack-udn.yaml
+++ b/modules/networking/attachments/dual-stack-vms/vm-dualstack-udn.yaml
@@ -5,23 +5,22 @@ metadata:
   namespace: dualstack-demo
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
         app: dualstack-udn-vm
     spec:
       domain:
-        resources:
-          requests:
-            memory: 2Gi
         devices:
           disks:
             - name: containerdisk
-              disk:
-                bus: virtio
+              disk: {}
             - name: cloudinitdisk
-              disk:
-                bus: virtio
+              disk: {}
           interfaces:
             - name: primary-udn
               binding:

--- a/modules/networking/attachments/linux-bridges/bridge-demo-vm.yaml
+++ b/modules/networking/attachments/linux-bridges/bridge-demo-vm.yaml
@@ -7,6 +7,10 @@ metadata:
     app: bridge-demo-vm
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   dataVolumeTemplates:
   - metadata:
       name: bridge-demo-volume
@@ -30,21 +34,15 @@ spec:
         devices:
           disks:
           - name: datavolumedisk
-            disk:
-              bus: virtio
+            disk: {}
           - name: cloudinitdisk
-            disk:
-              bus: virtio
+            disk: {}
           interfaces:
           - masquerade: {}
             name: default
           - bridge: {}
             model: virtio
             name: nic-linux-bridge
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: 1
       networks:
       - name: default
         pod: {}

--- a/modules/networking/attachments/linux-bridges/bridge-demo-vm.yaml
+++ b/modules/networking/attachments/linux-bridges/bridge-demo-vm.yaml
@@ -1,39 +1,37 @@
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name: bridge-demo-vm
+  name: fedora-bridge-demo
   namespace: bridge-demo
   labels:
-    app: bridge-demo-vm
+    app: fedora-bridge-demo
 spec:
   runStrategy: Always
-  instancetype:
-    name: u1.small
-  preference:
-    name: fedora
   dataVolumeTemplates:
   - metadata:
-      name: bridge-demo-volume
+      name: fedora-bridge-demo-root
     spec:
-      pvc:
-        accessModes:
-        - ReadWriteOnce
-        resources:
-          requests:
-            storage: 33Gi
       sourceRef:
         kind: DataSource
         name: fedora
         namespace: openshift-virtualization-os-images
+      storage:
+        resources:
+          requests:
+            storage: 30Gi
+  instancetype:
+    name: u1.large
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
-        app: bridge-demo-vm
+        app: fedora-bridge-demo
     spec:
       domain:
         devices:
           disks:
-          - name: datavolumedisk
+          - name: fedora-bridge-demo-root
             disk: {}
           - name: cloudinitdisk
             disk: {}
@@ -41,18 +39,17 @@ spec:
           - masquerade: {}
             name: default
           - bridge: {}
-            model: virtio
             name: nic-linux-bridge
       networks:
       - name: default
         pod: {}
       - multus:
-          networkName: lnbr0-nad
+          networkName: lnbr0-bridge
         name: nic-linux-bridge
       volumes:
-      - name: datavolumedisk
+      - name: fedora-bridge-demo-root
         dataVolume:
-          name: bridge-demo-volume
+          name: fedora-bridge-demo-root
       - name: cloudinitdisk
         cloudInitNoCloud:
           networkData: |
@@ -65,4 +62,5 @@ spec:
             #cloud-config
             user: fedora
             password: fedora
-            chpasswd: { expire: False }
+            chpasswd:
+              expire: false

--- a/modules/networking/attachments/linux-bridges/linux-bridge-nad.yaml
+++ b/modules/networking/attachments/linux-bridges/linux-bridge-nad.yaml
@@ -1,11 +1,11 @@
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:
-  name: lnbr0-nad
+  name: lnbr0-bridge
   namespace: bridge-demo
 spec:
   config: '{
-    "name": "lnbr0-nad",
+    "name": "lnbr0-bridge",
     "cniVersion": "0.3.1",
     "type": "bridge",
     "bridge": "lnbr0",

--- a/modules/networking/attachments/linux-bridges/linux-bridge-nncp-dhcp.yaml
+++ b/modules/networking/attachments/linux-bridges/linux-bridge-nncp-dhcp.yaml
@@ -1,7 +1,7 @@
 apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: lnbr0-policy
+  name: lnbr0-bridge
 spec:
   desiredState:
     interfaces:

--- a/modules/networking/attachments/linux-bridges/linux-bridge-nncp-layer2.yaml
+++ b/modules/networking/attachments/linux-bridges/linux-bridge-nncp-layer2.yaml
@@ -1,17 +1,21 @@
 apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: lnbr0-policy
+  name: lnbr0-bridge
 spec:
   desiredState:
     interfaces:
     - name: lnbr0
-      description: layer2-only linux bridge with ens1 as a port
+      description: layer2-only linux bridge with an optional port
       type: linux-bridge
       state: up
+      ipv4:
+        enabled: false
       bridge:
         options:
           stp:
             enabled: false
-        port:
-        - name: ens1
+        # Uncomment below and change the interface name
+        # to match the desired physical host port
+        #port:
+        #- name: ens1

--- a/modules/networking/attachments/linux-bridges/linux-bridge-nncp-static.yaml
+++ b/modules/networking/attachments/linux-bridges/linux-bridge-nncp-static.yaml
@@ -1,7 +1,7 @@
 apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: lnbr0-policy
+  name: lnbr0-bridge
 spec:
   desiredState:
     interfaces:

--- a/modules/networking/attachments/localnet-secondary/fedora-localnet-vm.yaml
+++ b/modules/networking/attachments/localnet-secondary/fedora-localnet-vm.yaml
@@ -7,6 +7,10 @@ metadata:
     app: fedora-localnet-vm
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   dataVolumeTemplates:
   - metadata:
       name: fedora-localnet-volume
@@ -30,20 +34,14 @@ spec:
         devices:
           disks:
           - name: datavolumedisk
-            disk:
-              bus: virtio
+            disk: {}
           - name: cloudinitdisk
-            disk:
-              bus: virtio
+            disk: {}
           interfaces:
           - name: default
             bridge: {}
           - name: secondary_localnet
             bridge: {}
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: 1
       networks:
       - name: default
         pod: {}

--- a/modules/networking/attachments/localnet-secondary/fedora-localnet-vm.yaml
+++ b/modules/networking/attachments/localnet-secondary/fedora-localnet-vm.yaml
@@ -58,7 +58,8 @@ spec:
             #cloud-config
             user: fedora
             password: fedora
-            chpasswd: { expire: False }
+            chpasswd:
+              expire: false
             packages:
             - python3
             runcmd:

--- a/modules/networking/attachments/localnet-vlan/fedora-vlan-vm.yaml
+++ b/modules/networking/attachments/localnet-vlan/fedora-vlan-vm.yaml
@@ -7,6 +7,10 @@ metadata:
     app: fedora-vlan-vm
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   dataVolumeTemplates:
   - metadata:
       name: fedora-vlan-volume
@@ -30,20 +34,14 @@ spec:
         devices:
           disks:
           - name: datavolumedisk
-            disk:
-              bus: virtio
+            disk: {}
           - name: cloudinitdisk
-            disk:
-              bus: virtio
+            disk: {}
           interfaces:
           - name: default
             bridge: {}
           - name: vlan_network
             bridge: {}
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: 1
       networks:
       - name: default
         pod: {}

--- a/modules/networking/attachments/localnet-vlan/fedora-vlan-vm.yaml
+++ b/modules/networking/attachments/localnet-vlan/fedora-vlan-vm.yaml
@@ -58,7 +58,8 @@ spec:
             #cloud-config
             user: fedora
             password: fedora
-            chpasswd: { expire: False }
+            chpasswd:
+              expire: false
             packages:
             - python3
             - tcpdump

--- a/modules/networking/attachments/metallb-loadbalancer/vm-webserver.yaml
+++ b/modules/networking/attachments/metallb-loadbalancer/vm-webserver.yaml
@@ -7,23 +7,22 @@ metadata:
     app: web-vm
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
         app: web-vm
     spec:
       domain:
-        resources:
-          requests:
-            memory: 2Gi
         devices:
           disks:
             - name: containerdisk
-              disk:
-                bus: virtio
+              disk: {}
             - name: cloudinitdisk
-              disk:
-                bus: virtio
+              disk: {}
           interfaces:
             - name: default
               masquerade: {}

--- a/modules/networking/attachments/network-policies-vms/vm-db.yaml
+++ b/modules/networking/attachments/network-policies-vms/vm-db.yaml
@@ -8,6 +8,10 @@ metadata:
     role: backend
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -15,17 +19,12 @@ spec:
         role: backend
     spec:
       domain:
-        resources:
-          requests:
-            memory: 2Gi
         devices:
           disks:
             - name: containerdisk
-              disk:
-                bus: virtio
+              disk: {}
             - name: cloudinitdisk
-              disk:
-                bus: virtio
+              disk: {}
           interfaces:
             - name: default
               masquerade: {}

--- a/modules/networking/attachments/network-policies-vms/vm-web.yaml
+++ b/modules/networking/attachments/network-policies-vms/vm-web.yaml
@@ -8,6 +8,10 @@ metadata:
     role: frontend
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -15,17 +19,12 @@ spec:
         role: frontend
     spec:
       domain:
-        resources:
-          requests:
-            memory: 2Gi
         devices:
           disks:
             - name: containerdisk
-              disk:
-                bus: virtio
+              disk: {}
             - name: cloudinitdisk
-              disk:
-                bus: virtio
+              disk: {}
           interfaces:
             - name: default
               masquerade: {}

--- a/modules/networking/attachments/sriov-secondary/fedora-sriov-vm.yaml
+++ b/modules/networking/attachments/sriov-secondary/fedora-sriov-vm.yaml
@@ -7,6 +7,10 @@ metadata:
     app: fedora-sriov-vm
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.medium
+  preference:
+    name: fedora
   dataVolumeTemplates:
   - metadata:
       name: fedora-sriov-volume
@@ -30,11 +34,9 @@ spec:
         devices:
           disks:
           - name: datavolumedisk
-            disk:
-              bus: virtio
+            disk: {}
           - name: cloudinitdisk
-            disk:
-              bus: virtio
+            disk: {}
           interfaces:
           - name: default
             masquerade: {}
@@ -42,10 +44,6 @@ spec:
             sriov: {}
           - name: mgmt-plane
             sriov: {}
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 2
       networks:
       - name: default
         pod: {}
@@ -65,4 +63,5 @@ spec:
             #cloud-config
             user: fedora
             password: fedora
-            chpasswd: { expire: False }
+            chpasswd:
+              expire: false

--- a/modules/networking/attachments/static-ip-configuration/fedora-dhcp-reserved-vm.yaml
+++ b/modules/networking/attachments/static-ip-configuration/fedora-dhcp-reserved-vm.yaml
@@ -4,6 +4,10 @@ metadata:
   name: fedora-dhcp-reserved-vm
   namespace: static-ip-demo
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   dataVolumeTemplates:
     - apiVersion: cdi.kubevirt.io/v1beta1
       kind: DataVolume
@@ -25,15 +29,11 @@ spec:
         kubevirt.io/domain: fedora-dhcp-reserved-vm
     spec:
       domain:
-        cpu:
-          cores: 2
         devices:
           disks:
-            - disk:
-                bus: virtio
+            - disk: {}
               name: rootdisk
-            - disk:
-                bus: virtio
+            - disk: {}
               name: cloudinitdisk
           interfaces:
             - masquerade: {}
@@ -41,11 +41,6 @@ spec:
             - bridge: {}
               name: vlan-network
               macAddress: "02:00:00:01:00:01"
-          rng: {}
-        machine:
-          type: pc-q35-rhel9.4.0
-        memory:
-          guest: 4Gi
       networks:
         - name: default
           pod: {}
@@ -61,6 +56,7 @@ spec:
               #cloud-config
               user: fedora
               password: fedora123
-              chpasswd: { expire: False }
+              chpasswd:
+                expire: false
               ssh_pwauth: True
           name: cloudinitdisk

--- a/modules/networking/attachments/static-ip-configuration/fedora-multi-network-vm.yaml
+++ b/modules/networking/attachments/static-ip-configuration/fedora-multi-network-vm.yaml
@@ -4,6 +4,10 @@ metadata:
   name: fedora-multi-vm
   namespace: static-ip-demo
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   dataVolumeTemplates:
     - apiVersion: cdi.kubevirt.io/v1beta1
       kind: DataVolume
@@ -25,26 +29,17 @@ spec:
         kubevirt.io/domain: fedora-multi-vm
     spec:
       domain:
-        cpu:
-          cores: 2
         devices:
           disks:
-            - disk:
-                bus: virtio
+            - disk: {}
               name: rootdisk
-            - disk:
-                bus: virtio
+            - disk: {}
               name: cloudinitdisk
           interfaces:
             - masquerade: {}
               name: default
             - bridge: {}
               name: vlan-network
-          rng: {}
-        machine:
-          type: pc-q35-rhel9.4.0
-        memory:
-          guest: 4Gi
       networks:
         - name: default
           pod: {}
@@ -60,7 +55,8 @@ spec:
               #cloud-config
               user: fedora
               password: fedora123
-              chpasswd: { expire: False }
+              chpasswd:
+                expire: false
               ssh_pwauth: True
             networkData: |-
               version: 2

--- a/modules/networking/attachments/udn-primary-networks/fedora-vm-with-udn.yaml
+++ b/modules/networking/attachments/udn-primary-networks/fedora-vm-with-udn.yaml
@@ -8,6 +8,10 @@ metadata:
     network-type: udn-primary
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   dataVolumeTemplates:
   - metadata:
       name: fedora-udn-volume
@@ -31,19 +35,13 @@ spec:
         devices:
           disks:
           - name: datavolumedisk
-            disk:
-              bus: virtio
+            disk: {}
           - name: cloudinitdisk
-            disk:
-              bus: virtio
+            disk: {}
           interfaces:
           - name: default
             binding:
               name: l2bridge
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: 1
       networks:
       - name: default
         pod: {}
@@ -52,7 +50,7 @@ spec:
         dataVolume:
           name: fedora-udn-volume
       - name: cloudinitdisk
-        cloudInitNoCloud:          
+        cloudInitNoCloud:
           userData: |
             #cloud-config
             write_files:
@@ -60,10 +58,11 @@ spec:
               content: |
                 nameserver 172.30.0.10      # cluster DNS
                 search udn-primary-vm-guests.svc.cluster.local svc.cluster.local
-                options ndots:5            
+                options ndots:5
             user: fedora
             password: fedora
-            chpasswd: { expire: False }
+            chpasswd:
+              expire: false
             packages:
             - python3
             runcmd:

--- a/modules/networking/attachments/vm-ingress-routes/vm-webserver.yaml
+++ b/modules/networking/attachments/vm-ingress-routes/vm-webserver.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: ingress-demo
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -15,17 +19,12 @@ spec:
         devices:
           disks:
           - name: rootdisk
-            disk:
-              bus: virtio
+            disk: {}
           - name: cloudinitdisk
-            disk:
-              bus: virtio
+            disk: {}
           interfaces:
           - name: default
             masquerade: {}
-        resources:
-          requests:
-            memory: 1Gi
       networks:
       - name: default
         pod: {}
@@ -40,18 +39,17 @@ spec:
             password: redhat
             chpasswd:
               expire: false
-            packages:
-            - nginx
-            write_files:
-            - path: /usr/share/nginx/html/index.html
-              content: |
-                <html>
-                <head><title>OpenShift Virt - Ingress Demo</title></head>
-                <body>
-                <h1>Hello from OpenShift Virtualization</h1>
-                <p>This page is served by Nginx inside a VM, exposed via an OpenShift Route.</p>
-                </body>
-                </html>
             runcmd:
+            - dnf install -y nginx
+            - |
+              cat > /usr/share/nginx/html/index.html <<'HTMLEOF'
+              <html>
+              <head><title>OpenShift Virt - Ingress Demo</title></head>
+              <body>
+              <h1>Hello from OpenShift Virtualization</h1>
+              <p>This page is served by Nginx inside a VM, exposed via an OpenShift Route.</p>
+              </body>
+              </html>
+              HTMLEOF
             - systemctl enable nginx
             - systemctl start nginx

--- a/modules/networking/pages/cudn-localnet-vlan.adoc
+++ b/modules/networking/pages/cudn-localnet-vlan.adoc
@@ -175,6 +175,10 @@ metadata:
     app: fedora-cudn-vlan-vm
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   dataVolumeTemplates:
   - metadata:
       name: fedora-cudn-vlan-volume
@@ -198,20 +202,14 @@ spec:
         devices:
           disks:
           - name: datavolumedisk
-            disk:
-              bus: virtio
+            disk: {}
           - name: cloudinitdisk
-            disk:
-              bus: virtio
+            disk: {}
           interfaces:
           - name: default
             bridge: {}
           - name: cudn_vlan_network
             bridge: {}
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: 1
       networks:
       - name: default
         pod: {}
@@ -269,6 +267,10 @@ metadata:
     app: fedora-cudn-vlan-vm-dev
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   dataVolumeTemplates:
   - metadata:
       name: fedora-cudn-vlan-volume-dev
@@ -292,20 +294,14 @@ spec:
         devices:
           disks:
           - name: datavolumedisk
-            disk:
-              bus: virtio
+            disk: {}
           - name: cloudinitdisk
-            disk:
-              bus: virtio
+            disk: {}
           interfaces:
           - name: default
             bridge: {}
           - name: cudn_vlan_network
             bridge: {}
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: 1
       networks:
       - name: default
         pod: {}

--- a/modules/networking/pages/dual-stack-vms.adoc
+++ b/modules/networking/pages/dual-stack-vms.adoc
@@ -16,6 +16,8 @@ Dual-stack networking is required in many enterprise and government environments
 * Cluster admin access
 
 Versions tested:
+
+[source,bash]
 ----
 OpenShift 4.22
 ----
@@ -34,7 +36,8 @@ oc get network.config cluster -o jsonpath='{.status.clusterNetwork[*].cidr}'
 oc get network.config cluster -o jsonpath='{.status.serviceNetwork[*]}'
 ----
 
-Expected output for a dual-stack cluster:
+.Expected output
+[source,bash]
 ----
 10.128.0.0/14 fd01::/48
 172.30.0.0/16 fd02::/112
@@ -107,23 +110,22 @@ metadata:
   namespace: dualstack-demo
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
         app: dualstack-vm
     spec:
       domain:
-        resources:
-          requests:
-            memory: 2Gi
         devices:
           disks:
             - name: containerdisk
-              disk:
-                bus: virtio
+              disk: {}
             - name: cloudinitdisk
-              disk:
-                bus: virtio
+              disk: {}
           interfaces:
             - name: default
               masquerade: {}
@@ -152,12 +154,13 @@ spec:
               ethernets:
                 eth0:
                   dhcp4: true
-                  addresses: [ fd10:0:2::2/120 ]
+                  addresses:
+                    - fd10:0:2::2/120
                   gateway6: fd10:0:2::1
 EOF
 ----
 
-NOTE: The KubeVirt user guide uses `gateway6` and inline `addresses` format. This tutorial follows the same convention. While `gateway6` is deprecated in netplan 0.103+, KubeVirt's cloud-init implementation processes it correctly. If your guest OS warns about the deprecation, you can use `routes` entries instead (see <<_cloud_init_networkdata_reference>>).
+NOTE: While `gateway6` is deprecated in netplan 0.103+, KubeVirt's cloud-init implementation processes it correctly. If your guest OS warns about the deprecation, you can use `routes` entries instead (see <<_cloud_init_networkdata_reference>>).
 
 Wait for the VM to become ready:
 
@@ -182,7 +185,8 @@ Once logged in (user: `fedora` or `root`, password: `changeme`), check the netwo
 ip -4 addr show eth0
 ----
 
-Expected output shows a `10.0.2.x` address (internal masquerade subnet):
+.Expected output
+[source,bash]
 ----
 inet 10.0.2.2/24 brd 10.0.2.255 scope global dynamic eth0
 ----
@@ -192,7 +196,8 @@ inet 10.0.2.2/24 brd 10.0.2.255 scope global dynamic eth0
 ip -6 addr show eth0
 ----
 
-Expected output shows the configured IPv6 address:
+.Expected output
+[source,bash]
 ----
 inet6 fd10:0:2::2/120 scope global
 ----
@@ -259,7 +264,8 @@ Verify the Service has dual-stack ClusterIPs:
 oc get svc dualstack-web -n dualstack-demo -o jsonpath='{.spec.clusterIPs}'
 ----
 
-Expected output shows two IPs (one IPv4, one IPv6):
+.Expected output
+[source,bash]
 ----
 ["172.30.x.x","fd02::x"]
 ----
@@ -343,23 +349,22 @@ metadata:
   namespace: dualstack-demo
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
         app: dualstack-udn-vm
     spec:
       domain:
-        resources:
-          requests:
-            memory: 2Gi
         devices:
           disks:
             - name: containerdisk
-              disk:
-                bus: virtio
+              disk: {}
             - name: cloudinitdisk
-              disk:
-                bus: virtio
+              disk: {}
           interfaces:
             - name: primary-udn
               binding:
@@ -386,7 +391,7 @@ With IPAM lifecycle set to `Persistent`, the VM retains its IPv4 and IPv6 addres
 [[_cloud_init_networkdata_reference]]
 == Cloud-init networkData Reference
 
-The `networkData` field uses netplan version 2 format. The KubeVirt user guide and OpenShift documentation use the `gateway6` field with inline `addresses`:
+The `networkData` field uses netplan version 2 format. The KubeVirt user guide and OpenShift documentation use the `gateway6` field:
 
 [source,yaml]
 ----
@@ -394,7 +399,8 @@ version: 2
 ethernets:
   eth0:
     dhcp4: true
-    addresses: [ fd10:0:2::2/120 ]
+    addresses:
+      - fd10:0:2::2/120
     gateway6: fd10:0:2::1
 ----
 

--- a/modules/networking/pages/linux-bridges.adoc
+++ b/modules/networking/pages/linux-bridges.adoc
@@ -270,11 +270,9 @@ spec:
         devices:
           disks:
           - name: fedora-bridge-demo-root
-            disk:
-              bus: virtio
+            disk: {}
           - name: cloudinitdisk
-            disk:
-              bus: virtio
+            disk: {}
           interfaces:
           - masquerade: {}
             name: default
@@ -306,16 +304,18 @@ spec:
               expire: false
 ----
 
-Reviewing specific fields from the above example (all field paths are relative to `spec.template.spec`):
+Reviewing specific fields from the above example (all field paths are relative to `spec`):
 
-* *`domain.devices.interfaces`*: lists two interfaces, the primary `default` and the secondary `nic-linux-bridge`
+* *`instancetype`*: references the `u1.large` cluster instancetype, which defines CPU and memory resources. This removes the need for inline `domain.resources` or `domain.cpu` fields.
+* *`preference`*: references the `fedora` cluster preference, which provides Fedora-specific settings such as preferred disk bus types, machine type, and firmware configuration.
+* *`template.spec.domain.devices.interfaces`*: lists two interfaces, the primary `default` and the secondary `nic-linux-bridge`
 ** *`bridge`*: one of two ways to connect a VM nic to the host container (the other is IP `masquerade`).
 This uses a vm-to-container bridge, whereas the `lnbr0` bridge connects container-to-node (completing the connection).
 ** *`name`*: an arbitrary identifier which gets referred to later in the `network` section.
-* *`networks`*: list of networks to which the `interfaces` are attached.
+* *`template.spec.networks`*: list of networks to which the `interfaces` are attached.
 ** *`name`*: the name of the bridge interface as defined in the `interfaces` field.
 ** *`multus.networkName`*: the name of the NetworkAttachmentDefinition (NAD) providing pods/VMs access to the bridge network.
-* *`volumes`*: there are two named volumes: one is the root `datavolumedisk`, and the other is the `cloudinitdisk`
+* *`template.spec.volumes`*: there are two named volumes: one is the root `datavolumedisk`, and the other is the `cloudinitdisk`
 ** *`CloudInitNoCloud`*: informs kubevirt that this is a cloud-init disk and to use the https://cloudinit.readthedocs.io/en/latest/reference/datasources/nocloud.html[NoCloud,window=_blank] data source
 *** *`networkData`*: this configures a static IP (`192.168.50.10/24`) on the secondary interface (`enp2s0`)
 **** *`ethernets`*: The secondary interface name `enp2s0` follows KubeVirt's predictable naming convention for the second network interface
@@ -378,11 +378,9 @@ spec:
         devices:
           disks:
           - name: fedora-bridge-demo2-root
-            disk:
-              bus: virtio
+            disk: {}
           - name: cloudinitdisk
-            disk:
-              bus: virtio
+            disk: {}
           interfaces:
           - masquerade: {}
             name: default

--- a/modules/networking/pages/localnet-secondary.adoc
+++ b/modules/networking/pages/localnet-secondary.adoc
@@ -111,6 +111,10 @@ metadata:
     app: fedora-localnet-vm
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   dataVolumeTemplates:
   - metadata:
       name: fedora-localnet-volume
@@ -134,20 +138,14 @@ spec:
         devices:
           disks:
           - name: datavolumedisk
-            disk:
-              bus: virtio
+            disk: {}
           - name: cloudinitdisk
-            disk:
-              bus: virtio
+            disk: {}
           interfaces:
           - name: default
             bridge: {}
           - name: secondary_localnet
             bridge: {}
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: 1
       networks:
       - name: default
         pod: {}

--- a/modules/networking/pages/localnet-vlan.adoc
+++ b/modules/networking/pages/localnet-vlan.adoc
@@ -124,6 +124,10 @@ metadata:
     app: fedora-vlan-vm
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   dataVolumeTemplates:
   - metadata:
       name: fedora-vlan-volume
@@ -147,20 +151,14 @@ spec:
         devices:
           disks:
           - name: datavolumedisk
-            disk:
-              bus: virtio
+            disk: {}
           - name: cloudinitdisk
-            disk:
-              bus: virtio
+            disk: {}
           interfaces:
           - name: default
             bridge: {}
           - name: vlan_network
             bridge: {}
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: 1
       networks:
       - name: default
         pod: {}

--- a/modules/networking/pages/metallb-loadbalancer.adoc
+++ b/modules/networking/pages/metallb-loadbalancer.adoc
@@ -195,23 +195,22 @@ metadata:
     app: web-vm
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
         app: web-vm
     spec:
       domain:
-        resources:
-          requests:
-            memory: 2Gi
         devices:
           disks:
             - name: containerdisk
-              disk:
-                bus: virtio
+              disk: {}
             - name: cloudinitdisk
-              disk:
-                bus: virtio
+              disk: {}
           interfaces:
             - name: default
               masquerade: {}
@@ -495,12 +494,7 @@ oc delete subscription metallb-operator -n metallb-system
 
 [source,bash,role=execute]
 ----
-CSV_NAME=$(oc get csv -n metallb-system -o jsonpath='{.items[0].metadata.name}')
-----
-
-[source,bash,role=execute]
-----
-oc delete csv -n metallb-system ${CSV_NAME}
+oc delete csv -n metallb-system -l operators.coreos.com/metallb-operator.metallb-system=
 ----
 
 [source,bash,role=execute]

--- a/modules/networking/pages/network-policies-vms.adoc
+++ b/modules/networking/pages/network-policies-vms.adoc
@@ -65,6 +65,10 @@ metadata:
     role: frontend
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -72,17 +76,12 @@ spec:
         role: frontend
     spec:
       domain:
-        resources:
-          requests:
-            memory: 2Gi
         devices:
           disks:
             - name: containerdisk
-              disk:
-                bus: virtio
+              disk: {}
             - name: cloudinitdisk
-              disk:
-                bus: virtio
+              disk: {}
           interfaces:
             - name: default
               masquerade: {}
@@ -124,6 +123,10 @@ metadata:
     role: backend
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -131,17 +134,12 @@ spec:
         role: backend
     spec:
       domain:
-        resources:
-          requests:
-            memory: 2Gi
         devices:
           disks:
             - name: containerdisk
-              disk:
-                bus: virtio
+              disk: {}
             - name: cloudinitdisk
-              disk:
-                bus: virtio
+              disk: {}
           interfaces:
             - name: default
               masquerade: {}
@@ -241,7 +239,8 @@ Verify traffic is now blocked. From the test pod, attempt to reach the web VM:
 oc exec -n default curl-test -- curl -s --connect-timeout 5 http://<web-vm-ip>:80
 ----
 
-Expected result:
+.Expected output
+[source,text]
 ----
 command terminated with exit code 28
 ----
@@ -380,7 +379,10 @@ Verify that the test pod (which does not have label `app: web`) cannot reach the
 oc exec -n default curl-test -- curl -s --connect-timeout 5 http://<db-vm-ip>:5432
 ----
 
-Replace `<db-vm-ip>` with the database VM IP from Step 2. Expected result:
+Replace `<db-vm-ip>` with the database VM IP from Step 2.
+
+.Expected output
+[source,text]
 ----
 command terminated with exit code 28
 ----
@@ -398,7 +400,8 @@ List all NetworkPolicy resources in the namespace to review your security postur
 oc get networkpolicy -n netpol-demo
 ----
 
-Expected output:
+.Expected output
+[source,text]
 ----
 NAME                     POD-SELECTOR   AGE
 allow-db-from-web        app=database   ...

--- a/modules/networking/pages/sriov-secondary.adoc
+++ b/modules/networking/pages/sriov-secondary.adoc
@@ -295,6 +295,10 @@ metadata:
     app: fedora-sriov-vm
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.medium
+  preference:
+    name: fedora
   dataVolumeTemplates:
   - metadata:
       name: fedora-sriov-volume
@@ -318,11 +322,9 @@ spec:
         devices:
           disks:
           - name: datavolumedisk
-            disk:
-              bus: virtio
+            disk: {}
           - name: cloudinitdisk
-            disk:
-              bus: virtio
+            disk: {}
           interfaces:
           - name: default
             masquerade: {}
@@ -330,10 +332,6 @@ spec:
             sriov: {}
           - name: mgmt-plane
             sriov: {}
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 2
       networks:
       - name: default
         pod: {}

--- a/modules/networking/pages/static-ip-configuration.adoc
+++ b/modules/networking/pages/static-ip-configuration.adoc
@@ -178,6 +178,10 @@ metadata:
   name: fedora-multi-vm
   namespace: static-ip-demo
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   dataVolumeTemplates:
     - apiVersion: cdi.kubevirt.io/v1beta1
       kind: DataVolume
@@ -199,26 +203,17 @@ spec:
         kubevirt.io/domain: fedora-multi-vm
     spec:
       domain:
-        cpu:
-          cores: 2
         devices:
           disks:
-            - disk:
-                bus: virtio
+            - disk: {}
               name: rootdisk
-            - disk:
-                bus: virtio
+            - disk: {}
               name: cloudinitdisk
           interfaces:
             - masquerade: {}
               name: default
             - bridge: {}
               name: vlan-network
-          rng: {}
-        machine:
-          type: pc-q35-rhel9.4.0
-        memory:
-          guest: 4Gi
       networks:
         - name: default
           pod: {}
@@ -443,6 +438,10 @@ metadata:
   name: fedora-dhcp-reserved-vm
   namespace: static-ip-demo
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   dataVolumeTemplates:
     - apiVersion: cdi.kubevirt.io/v1beta1
       kind: DataVolume
@@ -464,15 +463,11 @@ spec:
         kubevirt.io/domain: fedora-dhcp-reserved-vm
     spec:
       domain:
-        cpu:
-          cores: 2
         devices:
           disks:
-            - disk:
-                bus: virtio
+            - disk: {}
               name: rootdisk
-            - disk:
-                bus: virtio
+            - disk: {}
               name: cloudinitdisk
           interfaces:
             - masquerade: {}
@@ -480,11 +475,6 @@ spec:
             - bridge: {}
               name: vlan-network
               macAddress: "02:00:00:01:00:01"
-          rng: {}
-        machine:
-          type: pc-q35-rhel9.4.0
-        memory:
-          guest: 4Gi
       networks:
         - name: default
           pod: {}

--- a/modules/networking/pages/udn-primary-networks.adoc
+++ b/modules/networking/pages/udn-primary-networks.adoc
@@ -126,7 +126,7 @@ spec:
         dataVolume:
           name: fedora-udn-volume
       - name: cloudinitdisk
-        cloudInitNoCloud:          
+        cloudInitNoCloud:
           userData: |
             #cloud-config
             write_files:
@@ -134,7 +134,7 @@ spec:
               content: |
                 nameserver 172.30.0.10      # cluster DNS
                 search udn-primary-vm-guests.svc.cluster.local svc.cluster.local
-                options ndots:5            
+                options ndots:5
             user: fedora
             password: fedora
             chpasswd:

--- a/modules/networking/pages/udn-primary-networks.adoc
+++ b/modules/networking/pages/udn-primary-networks.adoc
@@ -6,6 +6,7 @@
 This tutorial shows you how to create a primary network using User Defined Networks (UDNs) with Layer 2 topology in OpenShift Virtualization. Instead of using the cluster's default network, UDNs let you define custom IP ranges and provide complete network isolation for applications within a specific namespace. This approach is ideal when applications need direct control over IP addressing or require custom networking requirements. The entire setup takes just 5 straightforward steps without requiring additional network attachment definitions.
 
 Versions tested:
+[source,text]
 ----
 OpenShift 4.19, 4.20, 4.21
 ----
@@ -83,6 +84,10 @@ metadata:
     network-type: udn-primary
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   dataVolumeTemplates:
   - metadata:
       name: fedora-udn-volume
@@ -106,19 +111,13 @@ spec:
         devices:
           disks:
           - name: datavolumedisk
-            disk:
-              bus: virtio
+            disk: {}
           - name: cloudinitdisk
-            disk:
-              bus: virtio
+            disk: {}
           interfaces:
           - name: default
             binding:
               name: l2bridge
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: 1
       networks:
       - name: default
         pod: {}
@@ -188,6 +187,7 @@ oc get svc
 ----
 
 Example output:
+[source,text]
 ----
 NAME                    TYPE           CLUSTER-IP      EXTERNAL-IP                                                                  PORT(S)        AGE
 fedora-vm-web-service   LoadBalancer   172.30.72.140   aa32981df19ad4959ae9a82fb9990db9-1996929606.ca-central-1.elb.amazonaws.com   80:32291/TCP   45m
@@ -201,6 +201,7 @@ curl aa32981df19ad4959ae9a82fb9990db9-1996929606.ca-central-1.elb.amazonaws.com
 ----
 
 Expected output:
+[source,html]
 ----
 <h1>Welcome to OpenShift Virtualization !!!</h1>
 ----

--- a/modules/networking/pages/vm-ingress-routes.adoc
+++ b/modules/networking/pages/vm-ingress-routes.adoc
@@ -16,6 +16,7 @@ This approach uses the same OpenShift Ingress infrastructure that serves contain
 * **Ingress controller** running (default with OpenShift installation)
 
 Versions tested:
+[source,text]
 ----
 OpenShift 4.20
 ----
@@ -45,6 +46,10 @@ metadata:
   namespace: ingress-demo
 spec:
   runStrategy: Always
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -55,17 +60,12 @@ spec:
         devices:
           disks:
           - name: rootdisk
-            disk:
-              bus: virtio
+            disk: {}
           - name: cloudinitdisk
-            disk:
-              bus: virtio
+            disk: {}
           interfaces:
           - name: default
             masquerade: {}
-        resources:
-          requests:
-            memory: 1Gi
       networks:
       - name: default
         pod: {}
@@ -80,19 +80,18 @@ spec:
             password: redhat
             chpasswd:
               expire: false
-            packages:
-            - nginx
-            write_files:
-            - path: /usr/share/nginx/html/index.html
-              content: |
-                <html>
-                <head><title>OpenShift Virt - Ingress Demo</title></head>
-                <body>
-                <h1>Hello from OpenShift Virtualization</h1>
-                <p>This page is served by Nginx inside a VM, exposed via an OpenShift Route.</p>
-                </body>
-                </html>
             runcmd:
+            - dnf install -y nginx
+            - |
+              cat > /usr/share/nginx/html/index.html <<'HTMLEOF'
+              <html>
+              <head><title>OpenShift Virt - Ingress Demo</title></head>
+              <body>
+              <h1>Hello from OpenShift Virtualization</h1>
+              <p>This page is served by Nginx inside a VM, exposed via an OpenShift Route.</p>
+              </body>
+              </html>
+              HTMLEOF
             - systemctl enable nginx
             - systemctl start nginx
 EOF
@@ -168,7 +167,8 @@ Confirm it has an endpoint:
 oc get endpoints web-vm-svc -n ingress-demo
 ----
 
-Expected output:
+.Expected output
+[source,text]
 ----
 NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
 web-vm-svc   ClusterIP   172.30.x.x      <none>        80/TCP    5s
@@ -232,7 +232,8 @@ EOF
 oc get route web-vm-route -n ingress-demo
 ----
 
-Expected output:
+.Expected output
+[source,text]
 ----
 NAME           HOST/PORT                                          PATH  SERVICES     PORT  TERMINATION     WILDCARD
 web-vm-route   web-vm-route-ingress-demo.apps.ocplab01.example.com       web-vm-svc   80    edge/Redirect   None


### PR DESCRIPTION
Closes #345

## Summary
- Replace full VM spec (cpu, memory, resources) with `instancetype` and `preference` references across all networking tutorials and their attachment YAML files
- Sync all attachment YAMLs with inline tutorial content (chpasswd flow syntax, addresses flow syntax, naming inconsistencies, linux-bridges full rewrite)
- Fix code block language specifiers, expected output formatting, and cleanup steps in UDN, MetalLB, and network policies tutorials