### PR TITLE
USE instancetype/preference across storage tutorials

### DIFF
--- a/modules/performance/attachments/vm-monitoring-metrics/monitoring-test-vm.yaml
+++ b/modules/performance/attachments/vm-monitoring-metrics/monitoring-test-vm.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     app: monitoring-demo
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   runStrategy: Always
   template:
     metadata:
@@ -13,21 +17,15 @@ spec:
         kubevirt.io/domain: monitoring-test-vm
     spec:
       domain:
-        cpu:
-          cores: 2
-        memory:
-          guest: 2Gi
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+          - disk: {}
+            name: rootdisk
+          - disk: {}
+            name: cloudinitdisk
           interfaces:
-          - name: default
-            masquerade: {}
+          - masquerade: {}
+            name: default
       networks:
       - name: default
         pod: {}

--- a/modules/performance/pages/vm-monitoring-metrics.adoc
+++ b/modules/performance/pages/vm-monitoring-metrics.adoc
@@ -61,6 +61,10 @@ metadata:
   labels:
     app: monitoring-demo
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   runStrategy: Always
   template:
     metadata:
@@ -68,21 +72,15 @@ spec:
         kubevirt.io/domain: monitoring-test-vm
     spec:
       domain:
-        cpu:
-          cores: 2
-        memory:
-          guest: 2Gi
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+          - disk: {}
+            name: rootdisk
+          - disk: {}
+            name: cloudinitdisk
           interfaces:
-          - name: default
-            masquerade: {}
+          - masquerade: {}
+            name: default
       networks:
       - name: default
         pod: {}

--- a/modules/storage/attachments/expanding-vm-disk-size/vm-expansion.yaml
+++ b/modules/storage/attachments/expanding-vm-disk-size/vm-expansion.yaml
@@ -4,6 +4,10 @@ metadata:
   name: expansion-vm
   namespace: pvc-expansion-demo
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   runStrategy: Always
   template:
     metadata:
@@ -13,19 +17,13 @@ spec:
       domain:
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-            bootOrder: 1
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+          - disk: {}
+            name: rootdisk
+          - disk: {}
+            name: cloudinitdisk
           interfaces:
-          - name: default
-            masquerade: {}
-        resources:
-          requests:
-            memory: 1Gi
+          - masquerade: {}
+            name: default
       networks:
       - name: default
         pod: {}
@@ -41,17 +39,19 @@ spec:
             chpasswd:
               expire: false
   dataVolumeTemplates:
-  - metadata:
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    kind: DataVolume
+    metadata:
       name: expansion-vm-rootdisk
     spec:
-      pvc:
+      sourceRef:
+        kind: DataSource
+        name: fedora
+        namespace: openshift-virtualization-os-images
+      storage:
         accessModes:
         - ReadWriteOnce
         resources:
           requests:
             storage: 10Gi
         storageClassName: lvms-vg1
-      source:
-        registry:
-          pullMethod: node
-          url: docker://quay.io/containerdisks/fedora:latest

--- a/modules/storage/attachments/hostpath-provisioner/hpp-test-vm.yaml
+++ b/modules/storage/attachments/hostpath-provisioner/hpp-test-vm.yaml
@@ -4,6 +4,10 @@ metadata:
   name: hpp-test-vm
   namespace: default
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   runStrategy: Always
   template:
     metadata:
@@ -11,22 +15,15 @@ spec:
         kubevirt.io/vm: hpp-test-vm
     spec:
       domain:
-        cpu:
-          cores: 1
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+          - disk: {}
+            name: rootdisk
+          - disk: {}
+            name: cloudinitdisk
           interfaces:
-          - name: default
-            masquerade: {}
-        resources:
-          requests:
-            memory: 1Gi
+          - masquerade: {}
+            name: default
       networks:
       - name: default
         pod: {}
@@ -43,7 +40,9 @@ spec:
             chpasswd:
               expire: false
   dataVolumeTemplates:
-  - metadata:
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    kind: DataVolume
+    metadata:
       name: hpp-test-vm-rootdisk
     spec:
       storage:

--- a/modules/storage/attachments/multi-disk-configuration/vm-multi-disk.yaml
+++ b/modules/storage/attachments/multi-disk-configuration/vm-multi-disk.yaml
@@ -4,6 +4,10 @@ metadata:
   name: multi-disk-vm
   namespace: multi-disk-demo
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   runStrategy: Always
   template:
     metadata:
@@ -13,22 +17,15 @@ spec:
       domain:
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-            bootOrder: 1
-          - name: datadisk
-            disk:
-              bus: virtio
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+          - disk: {}
+            name: rootdisk
+          - disk: {}
+            name: datadisk
+          - disk: {}
+            name: cloudinitdisk
           interfaces:
-          - name: default
-            masquerade: {}
-        resources:
-          requests:
-            memory: 1Gi
+          - masquerade: {}
+            name: default
       networks:
       - name: default
         pod: {}
@@ -47,29 +44,33 @@ spec:
             chpasswd:
               expire: false
   dataVolumeTemplates:
-  - metadata:
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    kind: DataVolume
+    metadata:
       name: multi-disk-rootdisk
     spec:
-      pvc:
+      sourceRef:
+        kind: DataSource
+        name: fedora
+        namespace: openshift-virtualization-os-images
+      storage:
         accessModes:
         - ReadWriteOnce
         resources:
           requests:
             storage: 30Gi
         storageClassName: lvms-vg1
-      source:
-        registry:
-          pullMethod: node
-          url: docker://quay.io/containerdisks/fedora:latest
-  - metadata:
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    kind: DataVolume
+    metadata:
       name: multi-disk-datadisk
     spec:
-      pvc:
+      source:
+        blank: {}
+      storage:
         accessModes:
         - ReadWriteOnce
         resources:
           requests:
             storage: 10Gi
         storageClassName: lvms-vg1-retain
-      source:
-        blank: {}

--- a/modules/storage/attachments/odf-ceph-storage/test-vm-odf.yaml
+++ b/modules/storage/attachments/odf-ceph-storage/test-vm-odf.yaml
@@ -4,6 +4,10 @@ metadata:
   name: test-vm-odf
   namespace: default
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   runStrategy: Halted
   template:
     metadata:
@@ -13,34 +17,31 @@ spec:
       domain:
         devices:
           disks:
-            - name: boot-disk
-              disk:
-                bus: virtio
+          - disk: {}
+            name: boot-disk
           interfaces:
-            - name: default
-              masquerade: {}
+          - masquerade: {}
+            name: default
+      networks:
+      - name: default
+        pod: {}
+      volumes:
+      - name: boot-disk
+        dataVolume:
+          name: test-vm-odf-boot
+  dataVolumeTemplates:
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    kind: DataVolume
+    metadata:
+      name: test-vm-odf-boot
+    spec:
+      source:
+        registry:
+          url: docker://quay.io/containerdisks/fedora:latest
+      storage:
+        accessModes:
+        - ReadWriteOnce
         resources:
           requests:
-            memory: 1Gi
-            cpu: 1
-      networks:
-        - name: default
-          pod: {}
-      volumes:
-        - name: boot-disk
-          dataVolume:
-            name: test-vm-odf-boot
-  dataVolumeTemplates:
-    - metadata:
-        name: test-vm-odf-boot
-      spec:
-        source:
-          registry:
-            url: docker://quay.io/containerdisks/fedora:latest
-        pvc:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 10Gi
-          storageClassName: ocs-storagecluster-ceph-rbd
+            storage: 10Gi
+        storageClassName: ocs-storagecluster-ceph-rbd

--- a/modules/storage/pages/expanding-vm-disk-size.adoc
+++ b/modules/storage/pages/expanding-vm-disk-size.adoc
@@ -58,7 +58,7 @@ oc create namespace pvc-expansion-demo
 
 Deploy a Fedora VM with a single 10Gi boot disk. This is the disk you will expand in later steps.
 
-* **rootdisk**: Boot disk (10Gi, `lvms-vg1` StorageClass) imported from the Fedora container disk image
+* **rootdisk**: Boot disk (10Gi, `lvms-vg1` StorageClass) cloned from the Fedora boot source
 * **cloudinitdisk**: Cloud-init configuration for console login
 
 WARNING: The cloud-init password in this example is for demo purposes only. Always use a strong, unique password or SSH key authentication in production environments.
@@ -74,6 +74,10 @@ metadata:
   name: expansion-vm
   namespace: pvc-expansion-demo
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   runStrategy: Always
   template:
     metadata:
@@ -83,19 +87,13 @@ spec:
       domain:
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-            bootOrder: 1
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+          - disk: {}
+            name: rootdisk
+          - disk: {}
+            name: cloudinitdisk
           interfaces:
-          - name: default
-            masquerade: {}
-        resources:
-          requests:
-            memory: 1Gi
+          - masquerade: {}
+            name: default
       networks:
       - name: default
         pod: {}
@@ -111,20 +109,22 @@ spec:
             chpasswd:
               expire: false
   dataVolumeTemplates:
-  - metadata:
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    kind: DataVolume
+    metadata:
       name: expansion-vm-rootdisk
     spec:
-      pvc:
+      sourceRef:
+        kind: DataSource
+        name: fedora
+        namespace: openshift-virtualization-os-images
+      storage:
         accessModes:
         - ReadWriteOnce
         resources:
           requests:
             storage: 10Gi
         storageClassName: lvms-vg1
-      source:
-        registry:
-          pullMethod: node
-          url: docker://quay.io/containerdisks/fedora:latest
 EOF
 ----
 

--- a/modules/storage/pages/hostpath-provisioner.adoc
+++ b/modules/storage/pages/hostpath-provisioner.adoc
@@ -431,6 +431,10 @@ metadata:
   name: hpp-test-vm
   namespace: default
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   runStrategy: Always
   template:
     metadata:
@@ -438,22 +442,15 @@ spec:
         kubevirt.io/vm: hpp-test-vm
     spec:
       domain:
-        cpu:
-          cores: 1
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+          - disk: {}
+            name: rootdisk
+          - disk: {}
+            name: cloudinitdisk
           interfaces:
-          - name: default
-            masquerade: {}
-        resources:
-          requests:
-            memory: 1Gi
+          - masquerade: {}
+            name: default
       networks:
       - name: default
         pod: {}
@@ -470,7 +467,9 @@ spec:
             chpasswd:
               expire: false
   dataVolumeTemplates:
-  - metadata:
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    kind: DataVolume
+    metadata:
       name: hpp-test-vm-rootdisk
     spec:
       storage:

--- a/modules/storage/pages/multi-disk-configuration.adoc
+++ b/modules/storage/pages/multi-disk-configuration.adoc
@@ -93,6 +93,10 @@ metadata:
   name: multi-disk-vm
   namespace: multi-disk-demo
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   runStrategy: Always
   template:
     metadata:
@@ -102,22 +106,15 @@ spec:
       domain:
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-            bootOrder: 1
-          - name: datadisk
-            disk:
-              bus: virtio
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+          - disk: {}
+            name: rootdisk
+          - disk: {}
+            name: datadisk
+          - disk: {}
+            name: cloudinitdisk
           interfaces:
-          - name: default
-            masquerade: {}
-        resources:
-          requests:
-            memory: 1Gi
+          - masquerade: {}
+            name: default
       networks:
       - name: default
         pod: {}
@@ -136,39 +133,43 @@ spec:
             chpasswd:
               expire: false
   dataVolumeTemplates:
-  - metadata:
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    kind: DataVolume
+    metadata:
       name: multi-disk-rootdisk
     spec:
-      pvc:
+      sourceRef:
+        kind: DataSource
+        name: fedora
+        namespace: openshift-virtualization-os-images
+      storage:
         accessModes:
         - ReadWriteOnce
         resources:
           requests:
             storage: 30Gi
         storageClassName: lvms-vg1
-      source:
-        registry:
-          pullMethod: node
-          url: docker://quay.io/containerdisks/fedora:latest
-  - metadata:
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    kind: DataVolume
+    metadata:
       name: multi-disk-datadisk
     spec:
-      pvc:
+      source:
+        blank: {}
+      storage:
         accessModes:
         - ReadWriteOnce
         resources:
           requests:
             storage: 10Gi
         storageClassName: lvms-vg1-retain
-      source:
-        blank: {}
 EOF
 ----
 
 === Key Configuration Details
 
-* **`bootOrder: 1`** on the rootdisk ensures the VM boots from the OS disk.
-* **`source.registry`** on the rootdisk pulls the Fedora container disk image.
+* **`instancetype`** and **`preference`** define the VM's compute resources and OS-specific defaults, replacing inline `cpu`, `memory`, and `resources` fields.
+* **`sourceRef`** on the rootdisk clones from the Fedora boot source in the `openshift-virtualization-os-images` namespace.
 * **`source.blank: {}`** on the datadisk creates an empty, unformatted volume.
 * Each `dataVolumeTemplates` entry can specify a different `storageClassName`.
 * Disk names in `devices.disks` must match volume names in `volumes`, which must match `dataVolumeTemplates` metadata names.

--- a/modules/storage/pages/odf-ceph-storage.adoc
+++ b/modules/storage/pages/odf-ceph-storage.adoc
@@ -318,6 +318,10 @@ metadata:
   name: test-vm-odf
   namespace: default
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   runStrategy: Halted
   template:
     metadata:
@@ -327,37 +331,34 @@ spec:
       domain:
         devices:
           disks:
-            - name: boot-disk
-              disk:
-                bus: virtio
+          - disk: {}
+            name: boot-disk
           interfaces:
-            - name: default
-              masquerade: {}
+          - masquerade: {}
+            name: default
+      networks:
+      - name: default
+        pod: {}
+      volumes:
+      - name: boot-disk
+        dataVolume:
+          name: test-vm-odf-boot
+  dataVolumeTemplates:
+  - apiVersion: cdi.kubevirt.io/v1beta1
+    kind: DataVolume
+    metadata:
+      name: test-vm-odf-boot
+    spec:
+      source:
+        registry:
+          url: docker://quay.io/containerdisks/fedora:latest
+      storage:
+        accessModes:
+        - ReadWriteOnce
         resources:
           requests:
-            memory: 1Gi
-            cpu: 1
-      networks:
-        - name: default
-          pod: {}
-      volumes:
-        - name: boot-disk
-          dataVolume:
-            name: test-vm-odf-boot
-  dataVolumeTemplates:
-    - metadata:
-        name: test-vm-odf-boot
-      spec:
-        source:
-          registry:
-            url: docker://quay.io/containerdisks/fedora:latest
-        pvc:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 10Gi
-          storageClassName: ocs-storagecluster-ceph-rbd
+            storage: 10Gi
+        storageClassName: ocs-storagecluster-ceph-rbd
 EOF
 ----
 
@@ -444,28 +445,27 @@ kind: VirtualMachine
 metadata:
   name: multi-storage-vm
 spec:
+  instancetype:
+    name: u1.small
+  preference:
+    name: fedora
   runStrategy: Halted
   template:
     spec:
       domain:
         devices:
           disks:
-            - name: boot-disk
-              disk:
-                bus: virtio
-            - name: shared-data
-              disk:
-                bus: virtio
-        resources:
-          requests:
-            memory: 2Gi
+          - disk: {}
+            name: boot-disk
+          - disk: {}
+            name: shared-data
       volumes:
-        - name: boot-disk
-          persistentVolumeClaim:
-            claimName: vm-boot-rbd
-        - name: shared-data
-          persistentVolumeClaim:
-            claimName: vm-shared-cephfs
+      - name: boot-disk
+        persistentVolumeClaim:
+          claimName: vm-boot-rbd
+      - name: shared-data
+        persistentVolumeClaim:
+          claimName: vm-shared-cephfs
 EOF
 ----
 


### PR DESCRIPTION
Plaintext
Refactors several tutorial modules to use `instancetype` and `preference` configurations instead of legacy VM settings.

### Updated Modules
- `expanding-vm-disk-size`
- `hostpath-provisioner`
- `odf-ceph-storage`
- `multi-disk-configuration`
- `vm-monitoring-metrics`

Fixes #348
