### PR TITLE
Introduce checks for callout/annotation usage

### DIFF
--- a/.review-docs.conf
+++ b/.review-docs.conf
@@ -28,7 +28,14 @@
 # code-block-language = warning
 # yaml-null-timestamps = warning
 # yaml-flow-syntax = warning
+# callout-format = warning
 # yaml-validation = error
+# callout-count = warning
+#   Both auto-numbered (<.>) and manual callouts are accepted; mixing the
+#   two styles in the same block is always invalid. To repeat a manual
+#   marker, add the allow-duplicate-callouts attribute to the block, e.g.
+#   [source,yaml,allow-duplicate-callouts] or
+#   [source,yaml,allow-duplicate-callouts=true].
 #
 # ── Structural checks ──
 # trailing-newline = warning

--- a/.review-docs.conf
+++ b/.review-docs.conf
@@ -28,11 +28,11 @@
 # code-block-language = warning
 # yaml-null-timestamps = warning
 # yaml-flow-syntax = warning
+# yaml-validation = error
 #
 # ── Structural checks ──
 # trailing-newline = warning
 # tutorial-sections = warning
-# yaml-validation = error
 # nav-xrefs = error
 
 [product-names]

--- a/modules/api/pages/api-component-overview.adoc
+++ b/modules/api/pages/api-component-overview.adoc
@@ -90,8 +90,8 @@ At the API level, when a power command is issued against a VM with a `Manual` ru
 ----
 status:
   stateChangeRequests:
-  - action: <Stop|Start> <1>
-    uid: <uid-of-the-virtual-machine-instance> <2>
+  - action: <Stop|Start> # <1>
+    uid: <uid-of-the-virtual-machine-instance> # <2>
 ----
 <1> The action being requested. One of the following string values (`Stop`, `Start`).
 <2> The optional UID of the VirtualMachineInstance (_not_ the VirtualMachine) to perform the action against. This is not required for `Start` command since the VMI gets created when the VM starts.
@@ -318,7 +318,7 @@ See the sections on Networking for concrete usage examples when defining VMs.
 This is (as the name indicates) the default network used by pods in OpenShift and Kubernetes.
 It is chosen by simply defining an empty `pod: {}` network with an empty `masquerade: {}` interface, as in the below example:
 
-[source,yaml]
+[source,yaml,allow-duplicate-callouts]
 ----
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
@@ -331,11 +331,11 @@ spec:
       domain:
         devices:
           interfaces:
-          - name: default <1>
-            masquerade: {} <2>
+          - name: default # <1>
+            masquerade: {} # <2>
       networks:
-      - name: default <1>
-        pod: {} <3>
+      - name: default # <1>
+        pod: {} # <3>
 ----
 <1> the name of the network defined under `domain.devices.interfaces` (nested under `spec.template.spec`) must match the desired network name under `networks` within the VM template spec.
 <2> the default network uses IP masquerading (NAT) to connect the NIC to the underlying network
@@ -706,10 +706,10 @@ An example VirtualMachineExport is shown below:
 apiVersion: export.kubevirt.io/v1beta1
 kind: VirtualMachineExport
 metadata:
-  name: export-example <1>
+  name: export-example # <1>
 spec:
-  tokenSecretRef: export-token <2>
-  source: <3>
+  tokenSecretRef: export-token # <2>
+  source: # <3>
     apiGroup: "kubevirt.io"
     kind: VirtualMachine
     name: virtual-machine-example

--- a/modules/getting-started/pages/installing-qemu-guest-agent.adoc
+++ b/modules/getting-started/pages/installing-qemu-guest-agent.adoc
@@ -540,7 +540,7 @@ Copy the full service name from the first column (e.g., `qemu-ga@virtio\x2dports
 [source,bash]
 ----
 systemctl status \
-"qemu-ga@virtio\x2dports-org.qemu.guest_agent.0.service" <.>
+"qemu-ga@virtio\x2dports-org.qemu.guest_agent.0.service" # <.>
 ----
 <.> make sure the name of the service is wrapped in quotes
 
@@ -551,7 +551,7 @@ systemctl status \
 > "qemu-ga@virtio\x2dports-org.qemu.guest_agent.0.service"
 ● qemu-ga@virtio\x2dports-org.qemu.guest_agent.0.service - QEMU Guest Agent
    Loaded: loaded (/usr/lib/systemd/system/qemu-ga@.service; disabled; vendor p>
-   Active: active (running) since Wed 2026-07-08 18:37:41 UTC; 20h ago <.>
+   Active: active (running) since Wed 2026-07-08 18:37:41 UTC; 20h ago # <.>
      Docs: http://wiki.qemu.org/Features/GuestAgent
  Main PID: 2042 (qemu-ga)
     Tasks: 1
@@ -889,7 +889,7 @@ oc get vmi $VM_NAME -oyaml | yq -e '.status.interfaces[]'
 [source,bash]
 ----
 # example output
-infoSource: domain, guest-agent <1>
+infoSource: domain, guest-agent # <1>
 interfaceName: enp1s0
 ipAddress: 10.130.0.22
 ipAddresses:

--- a/modules/networking/pages/network-policies-vms.adoc
+++ b/modules/networking/pages/network-policies-vms.adoc
@@ -18,7 +18,7 @@ You will learn how to isolate VM traffic, permit specific port access between VM
 
 When OpenShift Virtualization creates a running VM, it spawns a virt-launcher pod. The labels you define in `spec.template.metadata.labels` of the VirtualMachine resource are applied to this pod. NetworkPolicy objects select these pods using `podSelector` just like any other workload.
 
-[source,yaml]
+[source,yaml,allow-duplicate-callouts]
 ----
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine

--- a/scripts/review_docs/WRITING_CHECKS.md
+++ b/scripts/review_docs/WRITING_CHECKS.md
@@ -36,7 +36,7 @@ def check_something(line: str, line_num: int, state: ParseState, cfg: Config, fi
 |------------|--------|-------------|
 | `name`     | `str`  | Unique identifier, kebab-case (e.g. `"my-new-check"`). Used in CLI flags, config file, and findings output. |
 | `severity` | `str`  | Default severity: `"error"` or `"warning"`. Users can override this in `.review-docs.conf` or via `--disable`. |
-| `scope`    | `str`  | Determines when the engine calls your function. One of: `"prose"`, `"code_block_content"`, `"code_block_boundary"`, `"structural"`. |
+| `scope`    | `str`  | Determines when the engine calls your function. One of: `"prose"`, `"code_block_line"`, `"code_block_boundary"`, `"code_block_complete"`, `"structural"`. |
 
 The decorator validates your function's parameter names against the
 expected signature for the given scope. If they don't match, a
@@ -64,7 +64,7 @@ def check_name(line: str, line_num: int, state: ParseState, cfg: Config, file_re
 Most checks are prose checks. Use this scope for anything that examines
 documentation text: style, formatting, terminology, heading structure.
 
-### `code_block_content`
+### `code_block_line`
 
 **When it runs:** On every line *inside* a `----`-delimited code block
 (not including the delimiter lines themselves).
@@ -76,12 +76,15 @@ The `state.code_block_lang` attribute tells you the language from the
 languages:
 
 ```python
-@register_check("yaml-something", "warning", "code_block_content")
+@register_check("yaml-something", "warning", "code_block_line")
 def check_yaml_something(line: str, line_num: int, state: ParseState, cfg: Config, file_result: FileResult) -> None:
     if state.code_block_lang != "yaml":
         return
     # ... inspect line ...
 ```
+
+Use this scope for checks that need to examine individual lines (e.g.,
+detecting specific patterns, validating line-level syntax).
 
 ### `code_block_boundary`
 
@@ -99,6 +102,77 @@ On open, `state.prev_line` contains the line immediately before the
 delimiter — typically the `[source,lang]` attribute, which you can
 inspect.
 
+### `code_block_complete`
+
+**When it runs:** Once per code block, when the closing `----` delimiter
+is encountered. Receives the accumulated block content and following
+annotation lines.
+
+**Signature:**
+
+```python
+def check_name(
+    block_content: list[str],
+    block_lang: str,
+    block_start_line: int,
+    block_end_line: int,
+    following_annotations: list[str],
+    block_attrs: dict[str, str],
+    cfg: Config,
+    file_result: FileResult,
+) -> None
+```
+
+**Parameters:**
+
+| Parameter               | Type              | Description |
+|-------------------------|-------------------|-------------|
+| `block_content`         | `list[str]`       | All lines inside the code block (excluding the `----` delimiters). |
+| `block_lang`            | `str`             | Language from `[source,lang]`, or `""` if none. |
+| `block_start_line`      | `int`             | Line number of the opening `----`. |
+| `block_end_line`        | `int`             | Line number of the closing `----`. |
+| `following_annotations` | `list[str]`       | Annotation lines immediately after the block (lines matching `^<(\d+|\.)>\s`). Engine stops at the first blank line or non-annotation line after the block. |
+| `block_attrs`           | `dict[str, str]`  | Named attributes parsed from the block-open attribute list, e.g. `[source,yaml,allow-duplicate-callouts]` → `{"source": "", "yaml": "", "allow-duplicate-callouts": ""}`. Bare attributes and `key=value` pairs are both captured; bare attributes get an empty-string value. |
+| `cfg`                   | `Config`          | Configuration object. |
+| `file_result`           | `FileResult`      | Result accumulator. |
+
+Use this scope for checks that need:
+- The complete block content (e.g., YAML validation, shell syntax)
+- To validate callouts against annotations
+- To analyze patterns across multiple lines in a block
+
+**Example:**
+
+```python
+@register_check("yaml-validation", "error", "code_block_complete")
+def check_yaml_validation(
+    block_content: list[str],
+    block_lang: str,
+    block_start_line: int,
+    block_end_line: int,
+    following_annotations: list[str],
+    block_attrs: dict[str, str],
+    cfg: Config,
+    file_result: FileResult,
+) -> None:
+    """Validate YAML syntax in code blocks."""
+    if block_lang != "yaml":
+        return
+    
+    import yaml
+    yaml_content = "\n".join(block_content)
+    
+    try:
+        yaml.safe_load(yaml_content)
+    except Exception:
+        file_result.add_finding(
+            cfg,
+            "yaml-validation",
+            block_start_line,
+            f"line {block_start_line}: Invalid YAML syntax in code block",
+        )
+```
+
 ### `structural`
 
 **When it runs:** Once per file, after all line-by-line processing is
@@ -113,6 +187,27 @@ def check_name(filepath: str, lines: list[str], cfg: Config, file_result: FileRe
 Use this for checks that need the whole file: validating required
 sections exist, cross-referencing with the filesystem, parsing
 multi-line constructs that span the entire document.
+
+---
+
+## Choosing between code block scopes
+
+There are three scopes for code block checks. Here's when to use each:
+
+| Scope | Use when... | Example checks |
+|-------|-------------|----------------|
+| `code_block_line` | You need to examine individual lines inside code blocks | `callout-format`, `yaml-null-timestamps`, `yaml-flow-syntax` |
+| `code_block_boundary` | You need to validate the opening or closing delimiter | `code-block-language` (checks for `[source,lang]` attribute) |
+| `code_block_complete` | You need the full block content or following annotations | `yaml-validation`, `callout-count`, JSON/shell syntax validation |
+
+**Rule of thumb:**
+- If your check can fire on a single line → `code_block_line`
+- If your check needs to validate the whole block → `code_block_complete`
+- If your check validates the `[source,lang]` attribute → `code_block_boundary`
+
+The engine handles all the code block parsing for you — accumulating
+content, detecting language, capturing annotations. You just pick the
+right scope and receive pre-parsed data.
 
 ---
 
@@ -427,8 +522,9 @@ The expected signatures per scope:
 | Scope                  | Parameters |
 |------------------------|------------|
 | `prose`                | `(line, line_num, state, cfg, file_result)` |
-| `code_block_content`   | `(line, line_num, state, cfg, file_result)` |
+| `code_block_line`      | `(line, line_num, state, cfg, file_result)` |
 | `code_block_boundary`  | `(line, line_num, state, cfg, file_result)` |
+| `code_block_complete`  | `(block_content, block_lang, block_start_line, block_end_line, following_annotations, block_attrs, cfg, file_result)` |
 | `structural`           | `(filepath, lines, cfg, file_result)` |
 
 ---

--- a/scripts/review_docs/checks/code_blocks.py
+++ b/scripts/review_docs/checks/code_blocks.py
@@ -6,6 +6,46 @@ from ..config import Config
 from ..models import FileResult, ParseState
 from ..registry import register_check
 
+# Language → line-comment prefix mapping for callout validation
+# None means the language has no comment syntax
+COMMENT_PREFIXES: dict[str, str | None] = {
+    # C-style languages
+    "c": "//", "cpp": "//", "java": "//", "javascript": "//", "js": "//",
+    "typescript": "//", "ts": "//", "go": "//", "rust": "//", "swift": "//",
+    "kotlin": "//", "scala": "//", "php": "//", "csharp": "//", "cs": "//",
+    "groovy": "//",
+    # Hash-comment languages
+    "ruby": "#", "python": "#", "perl": "#", "yaml": "#", "yml": "#",
+    "bash": "#", "sh": "#", "shell": "#", "zsh": "#", "makefile": "#",
+    "dockerfile": "#", "r": "#", "powershell": "#", "toml": "#",
+    "properties": "#", "ini": "#", "conf": "#", "awk": "#",
+    # Double-semicolon languages
+    "clojure": ";;", "lisp": ";;", "scheme": ";;", "elisp": ";;",
+    # XML-style (special handling)
+    "xml": "<!--", "html": "<!--", "sgml": "<!--", "svg": "<!--", "xhtml": "<!--",
+    # Double-dash languages
+    "sql": "--", "lua": "--", "haskell": "--", "ada": "--",
+    # No comment support
+    "json": None,
+}
+
+# A single callout token, either bare ("<1>", "<.>") or XML-commented
+# ("<!--1-->", "<!--.-->").
+_CALLOUT_TOKEN = r"(?:<!--(?:\d+|\.)-->|<(?:\d+|\.)>)"
+
+# One or more callout tokens separated only by whitespace, anchored to end of
+# line. A line may carry more than one callout (e.g. "code # <1> <2>"); this
+# confirms a genuine trailing callout group exists and captures its start.
+_CALLOUT_TAIL_RE = re.compile(rf"({_CALLOUT_TOKEN}(?:\s*{_CALLOUT_TOKEN})*)\s*$")
+
+# Non-anchored patterns used to pull individual markers out of a substring
+# once a trailing callout group has been confirmed.
+_BARE_TOKEN_RE = re.compile(r"<(\d+|\.)>")
+_XML_TOKEN_RE = re.compile(r"<!--(\d+|\.)-->")
+
+# Pattern to match a callout annotation line: "<1> explanation", "<.> explanation"
+_ANNOTATION_RE = re.compile(r"^<(\d+|\.)>\s")
+
 
 @register_check("code-block-language", "warning", "code_block_boundary")
 def check_code_block_language(
@@ -79,6 +119,102 @@ def check_yaml_flow_syntax(
             )
 
 
+def _report_bare_callouts(
+    cfg: Config,
+    file_result: FileResult,
+    line_num: int,
+    lang: str,
+    markers: list[str],
+    suggestion: str,
+) -> None:
+    """Report one finding covering every bare marker found in a callout tail."""
+    if not markers:
+        return
+    plural = "s" if len(markers) > 1 else ""
+    joined = ", ".join(markers)
+    file_result.add_finding(
+        cfg,
+        "callout-format",
+        line_num,
+        f"line {line_num}: Bare callout{plural} {joined} in {lang} block; {suggestion}",
+    )
+
+
+@register_check("callout-format", "warning", "code_block_line")
+def check_callout_format(
+    line: str,
+    line_num: int,
+    state: ParseState,
+    cfg: Config,
+    file_result: FileResult,
+) -> None:
+    """Check that callouts in code blocks use language-appropriate comment syntax.
+
+    A line may carry more than one callout (e.g. "code # <1> <2>"). Once a
+    trailing callout group is confirmed with ``_CALLOUT_TAIL_RE``, the parse
+    zone is widened back to "from the comment marker through end of line" so
+    every marker is validated, not just the last one.
+    """
+    lang = state.code_block_lang
+    if not lang or lang not in COMMENT_PREFIXES:
+        return  # Unknown language, skip
+
+    tail_match = _CALLOUT_TAIL_RE.search(line)
+    if not tail_match:
+        return  # No callout on this line
+
+    prefix = COMMENT_PREFIXES[lang]
+    group_start = tail_match.start(1)
+
+    # Locate the comment marker that should precede the callout group (if
+    # any) and widen the tail back to that point, so markers separated by
+    # other text are still caught.
+    if prefix is not None:
+        prefix_pos = line.rfind(prefix, 0, group_start + 1)
+        anchor = prefix_pos if prefix_pos != -1 else group_start
+    else:
+        anchor = group_start
+    tail = line[anchor:]
+
+    # Handle languages with no comment support: every callout is bare.
+    if prefix is None:
+        markers = [f"<{m}>" for m in _BARE_TOKEN_RE.findall(tail)]
+        _report_bare_callouts(
+            cfg,
+            file_result,
+            line_num,
+            lang,
+            markers,
+            f"{lang} has no comment syntax so callouts cannot be hidden",
+        )
+        return
+
+    # XML-style: expect <!--N--> format. Bare-token matching safely skips
+    # markers already wrapped in "<!--...-->" since the digits there aren't
+    # immediately preceded by "<".
+    if prefix == "<!--":
+        bare = [f"<{m}>" for m in _BARE_TOKEN_RE.findall(tail)]
+        _report_bare_callouts(cfg, file_result, line_num, lang, bare, "use '<!--N-->' format")
+        return
+
+    # Standard comment prefixes (#, //, --, ;;, ...): if the prefix actually
+    # precedes the callout group, every marker in the tail is considered
+    # hidden by that single comment. Otherwise, every marker is bare.
+    has_prefix = anchor != group_start
+    if has_prefix:
+        return  # Properly formatted
+
+    bare = [f"<{m}>" for m in _BARE_TOKEN_RE.findall(tail)]
+    _report_bare_callouts(
+        cfg,
+        file_result,
+        line_num,
+        lang,
+        bare,
+        f"use '{prefix} <N>' for valid syntax",
+    )
+
+
 @register_check("yaml-validation", "error", "code_block_complete")
 def check_yaml_validation(
     block_content: list[str],
@@ -111,4 +247,139 @@ def check_yaml_validation(
             "yaml-validation",
             block_start_line,
             f"line {block_start_line}: Invalid YAML syntax in code block",
+        )
+
+
+@register_check("callout-count", "warning", "code_block_complete")
+def check_callout_count(
+    block_content: list[str],
+    block_lang: str,
+    block_start_line: int,
+    block_end_line: int,
+    following_annotations: list[str],
+    block_attrs: dict[str, str],
+    cfg: Config,
+    file_result: FileResult,
+) -> None:
+    """Check that callout markers in code blocks match annotations that follow.
+
+    Both auto-numbered (``<.>``) and manual-numbered callouts are accepted
+    as a matter of author preference. Mixing the two styles in the same
+    block is always invalid. Manual numbering with repeated markers
+    requires the ``allow-duplicate-callouts`` attribute — bare or
+    ``=true`` — in its attribute list, e.g.
+    ``[source,yaml,allow-duplicate-callouts]``, to make that intent
+    explicit.
+    """
+
+    def report(msg: str) -> None:
+        file_result.add_finding(cfg, "callout-count", block_start_line, msg)
+
+    # Count callouts in block content
+    callout_numbers: set[int] = set()
+    auto_callout_count = 0
+    manual_callout_count = 0
+
+    for line in block_content:
+        # Non-anchored: a line may carry more than one callout marker
+        # (e.g. "code # <1> <2>"), so every marker must be counted, not just
+        # a single trailing one.
+        matches = _BARE_TOKEN_RE.findall(line)
+        for m in matches:
+            if m == ".":
+                auto_callout_count += 1
+            else:
+                callout_numbers.add(int(m))
+                manual_callout_count += 1
+
+    has_auto = auto_callout_count > 0
+    has_manual = len(callout_numbers) > 0
+
+    if not has_auto and not has_manual:
+        return  # No callouts in this block
+
+    # Count annotations
+    annotation_numbers: set[int] = set()
+    auto_annotation_count = 0
+
+    for line in following_annotations:
+        m = _ANNOTATION_RE.match(line)
+        if m:
+            val = m.group(1)
+            if val == ".":
+                auto_annotation_count += 1
+            else:
+                annotation_numbers.add(int(val))
+
+    raw_attr = block_attrs.get("allow-duplicate-callouts")
+    allow_duplicates = raw_attr is not None and raw_attr.lower() in ("", "true")
+
+    if has_auto and has_manual:
+        # Mixed auto and manual — always invalid, regardless of the attribute.
+        report(
+            f"line {block_start_line}: Code block mixes auto-numbered (<.>) "
+            f"and manual-numbered callouts; use one style consistently",
+        )
+        return
+
+    if has_auto:
+        # Auto-numbered block: an allow-duplicate-callouts attribute is moot
+        # since auto-numbering never repeats markers.
+        if allow_duplicates:
+            report(
+                f"line {block_start_line}: Code block declares allow-duplicate-callouts "
+                f"but uses auto-numbered (<.>) callouts; remove the attribute "
+                f"or switch to manual numbering",
+            )
+            return
+
+        # Auto-numbered: exact count match required.
+        if auto_callout_count != auto_annotation_count:
+            report(
+                f"line {block_start_line}: Code block has {auto_callout_count} "
+                f"auto-numbered callout(s) but {auto_annotation_count} annotation(s) follow",
+            )
+        return
+
+    # Manual-numbered: respected as author preference, no suggestion to
+    # switch to auto-numbering. Repeated markers require an explicit
+    # allow-duplicate-callouts opt-in.
+    has_duplicates = manual_callout_count > len(callout_numbers)
+
+    if has_duplicates and not allow_duplicates:
+        example = (
+            f"[source,{block_lang},allow-duplicate-callouts]"
+            if block_lang
+            else "[source,<language>,allow-duplicate-callouts]"
+        )
+        report(
+            f"line {block_start_line}: Code block has duplicate callout markers "
+            f"without the allow-duplicate-callouts block attribute; add "
+            f"allow-duplicate-callouts (e.g. {example}) to opt into repeated "
+            f"markers",
+        )
+        return
+
+    if allow_duplicates and not has_duplicates:
+        report(
+            f"line {block_start_line}: Code block declares allow-duplicate-callouts "
+            f"but has no duplicate callout markers; remove the attribute",
+        )
+        return
+
+    # Manual-numbered: check annotation set coverage.
+    missing = callout_numbers - annotation_numbers
+    if missing:
+        nums = ", ".join(f"<{n}>" for n in sorted(missing))
+        report(
+            f"line {block_start_line}: Callout(s) {nums} in code block "
+            f"have no matching annotation(s)",
+        )
+
+    unused = annotation_numbers - callout_numbers
+    if unused:
+        nums = ", ".join(f"<{n}>" for n in sorted(unused))
+        report(
+            f"line {block_start_line}: Annotation(s) {nums} not referenced "
+            f"in code block",
         )

--- a/scripts/review_docs/checks/code_blocks.py
+++ b/scripts/review_docs/checks/code_blocks.py
@@ -25,23 +25,16 @@ def check_code_block_language(
         return
 
     prev = state.prev_line
-    m = re.match(r"^\[source,?([a-zA-Z0-9_-]*)\]", prev) or re.match(
-        r"^\[source,?([a-zA-Z0-9_-]*),.*\]", prev
-    )
-    if not m:
-        # No [source,...] attribute — but also skip bare [source] or [source ...]
-        if not re.match(r"^\[source\s", prev) and not re.match(
-            r"^\[source\]", prev
-        ):
-            file_result.add_finding(
-                cfg,
-                "code-block-language",
-                line_num,
-                f"line {line_num}: Code block delimiter without [source,language] specifier",
-            )
+    if not re.match(r"^\[source(?:[,\s]|\])", prev):
+        file_result.add_finding(
+            cfg,
+            "code-block-language",
+            line_num,
+            f"line {line_num}: Code block delimiter without [source,language] specifier",
+        )
 
 
-@register_check("yaml-null-timestamps", "warning", "code_block_content")
+@register_check("yaml-null-timestamps", "warning", "code_block_line")
 def check_yaml_null_timestamps(
     line: str,
     line_num: int,
@@ -61,7 +54,7 @@ def check_yaml_null_timestamps(
         )
 
 
-@register_check("yaml-flow-syntax", "warning", "code_block_content")
+@register_check("yaml-flow-syntax", "warning", "code_block_line")
 def check_yaml_flow_syntax(
     line: str,
     line_num: int,
@@ -84,3 +77,38 @@ def check_yaml_flow_syntax(
                 line_num,
                 f"line {line_num}: Inline YAML flow syntax detected (use block style)",
             )
+
+
+@register_check("yaml-validation", "error", "code_block_complete")
+def check_yaml_validation(
+    block_content: list[str],
+    block_lang: str,
+    block_start_line: int,
+    block_end_line: int,
+    following_annotations: list[str],
+    block_attrs: dict[str, str],
+    cfg: Config,
+    file_result: FileResult,
+) -> None:
+    """Validate YAML syntax in code blocks (requires PyYAML)."""
+    if block_lang != "yaml":
+        return
+
+    try:
+        import yaml
+    except ImportError:
+        return
+
+    yaml_content = "\n".join(block_content)
+    if not yaml_content.strip():
+        return
+
+    try:
+        yaml.safe_load(yaml_content)
+    except Exception:
+        file_result.add_finding(
+            cfg,
+            "yaml-validation",
+            block_start_line,
+            f"line {block_start_line}: Invalid YAML syntax in code block",
+        )

--- a/scripts/review_docs/checks/structural.py
+++ b/scripts/review_docs/checks/structural.py
@@ -67,60 +67,6 @@ def check_tutorial_sections(
         )
 
 
-@register_check("yaml-validation", "error", "structural")
-def check_yaml_validation(
-    filepath: str,
-    lines: List[str],
-    cfg: Config,
-    file_result: FileResult,
-) -> None:
-    """Validate YAML syntax in code blocks (requires PyYAML)."""
-    try:
-        import yaml  # noqa: F401
-    except ImportError:
-        return
-
-    in_yaml_header = False
-    in_yaml_content = False
-    yaml_content = ""
-    block_start_line = 0
-
-    for line_num, line in enumerate(lines, 1):
-        # Detect start of YAML block
-        if re.match(r"^\[source,yaml", line):
-            in_yaml_header = True
-            yaml_content = ""
-            block_start_line = line_num
-            continue
-
-        # Detect code block delimiter
-        if re.match(r"^----", line):
-            if in_yaml_header:
-                in_yaml_header = False
-                in_yaml_content = True
-                continue
-            elif in_yaml_content:
-                # Validate accumulated YAML
-                if yaml_content.strip():
-                    try:
-                        import yaml as _yaml
-
-                        _yaml.safe_load(yaml_content)
-                    except Exception:
-                        file_result.add_finding(
-                            cfg,
-                            "yaml-validation",
-                            block_start_line,
-                            f"line {block_start_line}: Invalid YAML syntax in code block",
-                        )
-                yaml_content = ""
-                in_yaml_content = False
-                continue
-
-        if in_yaml_content:
-            yaml_content += line + "\n"
-
-
 @register_check("nav-xrefs", "error", "structural")
 def check_nav_xrefs(
     filepath: str,

--- a/scripts/review_docs/engine.py
+++ b/scripts/review_docs/engine.py
@@ -10,7 +10,7 @@ import re
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 from .config import Config
 from .models import FileResult, Finding, ParseState
@@ -18,6 +18,39 @@ from .registry import CHECKS
 
 # Ensure all checks are registered before the engine runs.
 from . import checks as _checks  # noqa: F401
+
+# Precompiled regex for annotation line detection (used during code block processing)
+_ANNOTATION_RE = re.compile(r"^<(\d+|\.)>\s")
+
+# Precompiled regex to extract the contents of a block attribute list,
+# e.g. ``[source,yaml,allow-duplicate-callouts]`` -> ``source,yaml,allow-duplicate-callouts``.
+_BLOCK_ATTR_LIST_RE = re.compile(r"^\[(.*)\]\s*$")
+
+
+def _parse_block_attrs(prev_line: str) -> Dict[str, str]:
+    """Parse named attributes from a block-open attribute line.
+
+    Handles lines like ``[source,yaml]``, ``[source,bash,role=execute]``,
+    or ``[source,yaml,allow-duplicate-callouts]``. Positional tokens (``source``,
+    ``bash``) are stored with an empty-string value alongside ``key=value``
+    pairs and bare named attributes (also empty-string value). Returns an
+    empty dict if *prev_line* is not a block attribute list.
+    """
+    m = _BLOCK_ATTR_LIST_RE.match(prev_line)
+    if not m:
+        return {}
+
+    attrs: Dict[str, str] = {}
+    for token in m.group(1).split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if "=" in token:
+            key, _, value = token.partition("=")
+            attrs[key.strip()] = value.strip().strip('"')
+        else:
+            attrs[token] = ""
+    return attrs
 
 
 # ── Build-check result ────────────────────────────────────────────────────────
@@ -38,7 +71,7 @@ class BuildResult:
 # are encountered.  Code blocks (``----`` / ``"code_block"``) are also
 # tracked on block_stack but handled in a dedicated branch because they
 # carry extra metadata (language, boundary direction) and dispatch to
-# their own check scopes (code_block_content, code_block_boundary).
+# their own check scopes (code_block_line, code_block_boundary, code_block_complete).
 # Note: ``--`` is a legitimate 2-character AsciiDoc open block delimiter.
 # False positives are unlikely because:
 #   1. Code blocks (``----``, 4+ dashes) are caught by a dedicated branch
@@ -145,12 +178,14 @@ def review_file(filepath: str, cfg: Config) -> FileResult:
 
     # Get enabled checks by scope
     prose_checks = _get_enabled_checks(cfg, "prose")
-    code_block_checks = _get_enabled_checks(cfg, "code_block_content")
+    code_block_line_checks = _get_enabled_checks(cfg, "code_block_line")
     boundary_checks = _get_enabled_checks(cfg, "code_block_boundary")
+    complete_checks = _get_enabled_checks(cfg, "code_block_complete")
     structural_checks = _get_enabled_checks(cfg, "structural")
 
     # Line-by-line state machine
     state = ParseState()
+    block_content_accumulator: List[str] = []
 
     for line_num, line in enumerate(lines, 1):
         # Skip comment lines for prose checks
@@ -164,6 +199,7 @@ def review_file(filepath: str, cfg: Config) -> FileResult:
                 state.block_stack.append("code_block")
                 state.code_block_start_line = line_num
                 state.boundary_direction = "open"
+                block_content_accumulator = []  # Reset accumulator
 
                 prev = state.prev_line
                 # Detect language specifier in previous line
@@ -171,9 +207,39 @@ def review_file(filepath: str, cfg: Config) -> FileResult:
                     r"^\[source,?([a-zA-Z0-9_-]*)\]", prev
                 ) or re.match(r"^\[source,?([a-zA-Z0-9_-]*),.*\]", prev)
                 state.code_block_lang = m.group(1) if m else ""
+                state.code_block_attrs = _parse_block_attrs(prev)
             else:
+                block_end_line = line_num
+
+                # Capture following annotation lines.
+                # AsciiDoc callout lists must be contiguous with the closing
+                # delimiter — any blank line terminates the list immediately.
+                following_annotations: List[str] = []
+                for i in range(line_num, len(lines)):  # line_num is 1-indexed, lines is 0-indexed
+                    next_line = lines[i]
+                    if not next_line.strip():
+                        break  # Blank line terminates annotation list
+                    if _ANNOTATION_RE.match(next_line):
+                        following_annotations.append(next_line)
+                    else:
+                        break  # Non-annotation line = end
+
+                # Dispatch to code_block_complete checks
+                for check_def in complete_checks:
+                    check_def.func(
+                        block_content_accumulator,
+                        state.code_block_lang,
+                        state.code_block_start_line,
+                        block_end_line,
+                        following_annotations,
+                        state.code_block_attrs,
+                        cfg,
+                        file_result,
+                    )
+
                 state.block_stack.pop()
                 state.code_block_lang = ""
+                state.code_block_attrs = {}
                 state.boundary_direction = "close"
 
             # Run boundary checks
@@ -183,9 +249,10 @@ def review_file(filepath: str, cfg: Config) -> FileResult:
             state.prev_line = line
             continue
 
-        # Inside code block: run code block content checks
+        # Inside code block: accumulate content and run line checks
         if state.in_code_block:
-            for check_def in code_block_checks:
+            block_content_accumulator.append(line)
+            for check_def in code_block_line_checks:
                 check_def.func(line, line_num, state, cfg, file_result)
 
             state.prev_line = line

--- a/scripts/review_docs/models.py
+++ b/scripts/review_docs/models.py
@@ -32,6 +32,10 @@ class ParseState:
     code_block_lang: str = ""
     code_block_start_line: int = 0
     boundary_direction: str = ""  # "open" or "close", set at ---- boundary
+    # Named attributes parsed from the block-open attribute list (e.g.
+    # ``[source,yaml,allow-duplicate-callouts]``). Bare attributes (no ``=value``)
+    # are stored with an empty-string value.
+    code_block_attrs: Dict[str, str] = field(default_factory=dict)
 
     # ── Heading tracking (managed by heading-hierarchy check) ─────────
     heading_levels: List[int] = field(default_factory=list)
@@ -130,7 +134,7 @@ class ReviewResult:
 
 
 class LineCheck(Protocol):
-    """Signature for prose, code_block_content, and code_block_boundary checks."""
+    """Signature for prose, code_block_line, and code_block_boundary checks."""
 
     def __call__(
         self,
@@ -154,19 +158,41 @@ class StructuralCheck(Protocol):
     ) -> None: ...
 
 
+class CodeBlockCompleteCheck(Protocol):
+    """Signature for checks that run once per completed code block."""
+
+    def __call__(
+        self,
+        block_content: List[str],
+        block_lang: str,
+        block_start_line: int,
+        block_end_line: int,
+        following_annotations: List[str],
+        block_attrs: Dict[str, str],
+        cfg: Config,
+        file_result: FileResult,
+    ) -> None: ...
+
+
 # Maps scope name -> (expected parameter names, protocol description)
 SCOPE_SIGNATURES: Dict[str, tuple[tuple[str, ...], str]] = {
     "prose": (
         ("line", "line_num", "state", "cfg", "file_result"),
         "LineCheck(line, line_num, state, cfg, file_result)",
     ),
-    "code_block_content": (
+    "code_block_line": (
         ("line", "line_num", "state", "cfg", "file_result"),
         "LineCheck(line, line_num, state, cfg, file_result)",
     ),
     "code_block_boundary": (
         ("line", "line_num", "state", "cfg", "file_result"),
         "LineCheck(line, line_num, state, cfg, file_result)",
+    ),
+    "code_block_complete": (
+        ("block_content", "block_lang", "block_start_line", "block_end_line",
+         "following_annotations", "block_attrs", "cfg", "file_result"),
+        "CodeBlockCompleteCheck(block_content, block_lang, block_start_line, "
+        "block_end_line, following_annotations, block_attrs, cfg, file_result)",
     ),
     "structural": (
         ("filepath", "lines", "cfg", "file_result"),
@@ -207,5 +233,5 @@ class CheckDef:
 
     name: str
     default_severity: str  # "error" or "warning"
-    scope: str  # "prose", "code_block_content", "code_block_boundary", or "structural"
+    scope: str  # "prose", "code_block_line", "code_block_boundary", "code_block_complete", or "structural"
     func: Callable

--- a/scripts/review_docs/registry.py
+++ b/scripts/review_docs/registry.py
@@ -27,8 +27,8 @@ def register_check(name: str, severity: str, scope: str):
     severity:
         Default severity — ``"error"`` or ``"warning"``.
     scope:
-        One of ``"prose"``, ``"code_block_content"``, ``"code_block_boundary"``,
-        or ``"structural"``.
+        One of ``"prose"``, ``"code_block_line"``, ``"code_block_boundary"``,
+        ``"code_block_complete"``, or ``"structural"``.
     """
 
     def decorator(func: Callable) -> Callable:


### PR DESCRIPTION
## Description

Introduce checks to standardize the usage of [AsciiDoc callouts](https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/) in modules.
- No preference on auto-numbered (`<.>`) vs manually numbered (`<1>`, `<2>`, ...)
- Disallow mixing of numbering styles (a code block should use one or the other)
- Disallow duplicate/reuse of numbers when manually numbered (unless `allow-duplicate-callouts` attribute is added on the code block)
- Ensure that:
  - When auto-numbering: number of callout markers == number of annotations
  - When manually numbering: all callout markers match to an annotation and that all annotations are referenced by at least one marker (when manually numbering)
- Regardless of numbering style, require the callout marker to be commented in the source language, e.g. `# <1>` (YAML, bash, etc.) or `// <.>` (C, Java, etc.)
  - AsciiDoc is fine with it either way (and will smartly strip out the trailing comment when it renders), but this allows the source code to still be valid YAML/bash/C/other language.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] New tutorial/content
- [ ] Bug fix (broken link, incorrect command, typo)
- [ ] Enhancement to existing content
- [ ] Documentation update
- [ ] Troubleshooting guide
- [ ] Manifest/example addition

## Related Issue

Part of #336

## Content Checklist

<!-- Mark completed items with an 'x' -->

### Technical Accuracy
- [ ] All commands have been tested on a live cluster
- [ ] YAML manifests are complete and valid (not partial snippets)
- [ ] Technical details verified against official documentation
- [ ] Use Professional language

### Testing & Verification
- [ ] Verified on OpenShift version: <!-- e.g., 4.20 -->
- [ ] All verification commands produce expected outputs
- [ ] Screenshots/outputs included (if applicable)

### Content Quality
- [ ] AsciiDoc syntax is correct
- [ ] Code blocks specify language (e.g., `[source,yaml]`)
- [ ] All internal links (xrefs) are working
- [ ] All external links use `window=_blank`
- [ ] Navigation (`nav.adoc`) updated if adding new pages
- [ ] Home page updated if adding new module/tutorial

### Build & Preview
- [ ] `npm run build` completes without errors
- [ ] Local preview verified (`npm run serve`)
- [ ] No broken xref warnings in build output
- [ ] All admonitions use correct syntax (NOTE:, WARNING:, etc.)

## Changes Made

<!-- Provide a bullet-point list of changes -->

- Introduce a new `code_block_complete` scope, which only fires once per code block
- Rename `code_block_content` scope to `code_block_line` scope (since it fires on every line of a code block)
- Move `yaml-validation` check to new `code_block_complete` scope
- Introduce new `callout-count` and `callout-format` checks
- Fix findings in modules

## Additional Notes

<!-- Any additional context, decisions made, or items for reviewers to pay special attention to -->

