### PR TITLE
Use instancetype/preference in vm-configuration edge case tutorials

### DIFF
--- a/modules/vm-configuration/attachments/internal-dns-for-vms/fedora-app-vm.yaml
+++ b/modules/vm-configuration/attachments/internal-dns-for-vms/fedora-app-vm.yaml
@@ -19,6 +19,10 @@ spec:
           resources:
             requests:
               storage: 30Gi
+  instancetype:
+    name: u1.large
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -28,18 +32,13 @@ spec:
       domain:
         devices:
           disks:
-            - disk:
-                bus: virtio
+            - disk: {}
               name: rootdisk
-            - disk:
-                bus: virtio
+            - disk: {}
               name: cloudinitdisk
           interfaces:
             - name: default
               masquerade: {}
-        resources:
-          requests:
-            memory: 2Gi
       networks:
         - name: default
           pod: {}
@@ -52,6 +51,7 @@ spec:
               #cloud-config
               user: fedora
               password: fedora
-              chpasswd: { expire: false }
+              chpasswd:
+                expire: false
               ssh_pwauth: true
           name: cloudinitdisk

--- a/modules/vm-configuration/attachments/node-placement-affinity/vm-node-affinity-preferred.yaml
+++ b/modules/vm-configuration/attachments/node-placement-affinity/vm-node-affinity-preferred.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: vm-placement
 spec:
   runStrategy: Manual
+  instancetype:
+    name: u1.large
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -13,41 +17,36 @@ spec:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: storage
-                operator: In
-                values:
-                - nvme
-          - weight: 50
-            preference:
-              matchExpressions:
-              - key: storage
-                operator: In
-                values:
-                - ssd
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: storage
+                    operator: In
+                    values:
+                      - nvme
+            - weight: 50
+              preference:
+                matchExpressions:
+                  - key: storage
+                    operator: In
+                    values:
+                      - ssd
       domain:
-        cpu:
-          cores: 2
-        memory:
-          guest: 2Gi
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+            - name: rootdisk
+              disk: {}
+            - name: cloudinitdisk
+              disk: {}
       volumes:
-      - name: rootdisk
-        containerDisk:
-          image: quay.io/containerdisks/fedora:43
-      - name: cloudinitdisk
-        cloudInitNoCloud:
-          userData: |
-            #cloud-config
-            user: fedora
-            password: fedora
-            chpasswd: { expire: False }
+        - name: rootdisk
+          containerDisk:
+            image: quay.io/containerdisks/fedora:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd:
+                expire: false

--- a/modules/vm-configuration/attachments/node-placement-affinity/vm-node-affinity-required.yaml
+++ b/modules/vm-configuration/attachments/node-placement-affinity/vm-node-affinity-required.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: vm-placement
 spec:
   runStrategy: Manual
+  instancetype:
+    name: u1.large
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -14,37 +18,32 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: gpu
-                operator: In
-                values:
-                - nvidia-t4
-                - nvidia-a100
-              - key: env
-                operator: In
-                values:
-                - production
+              - matchExpressions:
+                  - key: gpu
+                    operator: In
+                    values:
+                      - nvidia-t4
+                      - nvidia-a100
+                  - key: env
+                    operator: In
+                    values:
+                      - production
       domain:
-        cpu:
-          cores: 4
-        memory:
-          guest: 8Gi
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+            - name: rootdisk
+              disk: {}
+            - name: cloudinitdisk
+              disk: {}
       volumes:
-      - name: rootdisk
-        containerDisk:
-          image: quay.io/containerdisks/fedora:43
-      - name: cloudinitdisk
-        cloudInitNoCloud:
-          userData: |
-            #cloud-config
-            user: fedora
-            password: fedora
-            chpasswd: { expire: False }
+        - name: rootdisk
+          containerDisk:
+            image: quay.io/containerdisks/fedora:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd:
+                expire: false

--- a/modules/vm-configuration/attachments/node-placement-affinity/vm-node-selector.yaml
+++ b/modules/vm-configuration/attachments/node-placement-affinity/vm-node-selector.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: vm-placement
 spec:
   runStrategy: Manual
+  instancetype:
+    name: u1.large
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -13,26 +17,21 @@ spec:
       nodeSelector:
         storage: ssd  # VM will only run on nodes with storage=ssd label
       domain:
-        cpu:
-          cores: 2
-        memory:
-          guest: 4Gi
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+            - name: rootdisk
+              disk: {}
+            - name: cloudinitdisk
+              disk: {}
       volumes:
-      - name: rootdisk
-        containerDisk:
-          image: quay.io/containerdisks/fedora:43
-      - name: cloudinitdisk
-        cloudInitNoCloud:
-          userData: |
-            #cloud-config
-            user: fedora
-            password: fedora
-            chpasswd: { expire: False }
+        - name: rootdisk
+          containerDisk:
+            image: quay.io/containerdisks/fedora:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd:
+                expire: false

--- a/modules/vm-configuration/attachments/node-placement-affinity/vm-pod-affinity.yaml
+++ b/modules/vm-configuration/attachments/node-placement-affinity/vm-pod-affinity.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: vm-placement
 spec:
   runStrategy: Manual
+  instancetype:
+    name: u1.large
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -14,34 +18,29 @@ spec:
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - database
-            topologyKey: kubernetes.io/hostname
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - database
+              topologyKey: kubernetes.io/hostname
       domain:
-        cpu:
-          cores: 2
-        memory:
-          guest: 2Gi
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+            - name: rootdisk
+              disk: {}
+            - name: cloudinitdisk
+              disk: {}
       volumes:
-      - name: rootdisk
-        containerDisk:
-          image: quay.io/containerdisks/fedora:43
-      - name: cloudinitdisk
-        cloudInitNoCloud:
-          userData: |
-            #cloud-config
-            user: fedora
-            password: fedora
-            chpasswd: { expire: False }
+        - name: rootdisk
+          containerDisk:
+            image: quay.io/containerdisks/fedora:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd:
+                expire: false

--- a/modules/vm-configuration/attachments/node-placement-affinity/vm-pod-anti-affinity.yaml
+++ b/modules/vm-configuration/attachments/node-placement-affinity/vm-pod-anti-affinity.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: vm-placement
 spec:
   runStrategy: Manual
+  instancetype:
+    name: u1.large
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -14,34 +18,29 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - redis-cache
-            topologyKey: kubernetes.io/hostname
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - redis-cache
+              topologyKey: kubernetes.io/hostname
       domain:
-        cpu:
-          cores: 2
-        memory:
-          guest: 4Gi
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+            - name: rootdisk
+              disk: {}
+            - name: cloudinitdisk
+              disk: {}
       volumes:
-      - name: rootdisk
-        containerDisk:
-          image: quay.io/containerdisks/fedora:43
-      - name: cloudinitdisk
-        cloudInitNoCloud:
-          userData: |
-            #cloud-config
-            user: fedora
-            password: fedora
-            chpasswd: { expire: False }
+        - name: rootdisk
+          containerDisk:
+            image: quay.io/containerdisks/fedora:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd:
+                expire: false

--- a/modules/vm-configuration/attachments/remote-access-linux-vms/fedora-access-vm.yaml
+++ b/modules/vm-configuration/attachments/remote-access-linux-vms/fedora-access-vm.yaml
@@ -29,18 +29,16 @@ spec:
       domain:
         devices:
           disks:
-            - name: rootdisk
-              disk:
-                bus: virtio
-            - name: cloudinitdisk
-              disk:
-                bus: virtio
+            - disk: {}
+              name: rootdisk
+            - disk: {}
+              name: cloudinitdisk
           interfaces:
-            - name: default
-              masquerade:
+            - masquerade: {}
+              name: default
       networks:
         - name: default
-          pod:
+          pod: {}
       volumes:
         - dataVolume:
             name: fedora-access-vm-disk

--- a/modules/vm-configuration/attachments/remote-access-linux-vms/fedora-access-vm.yaml
+++ b/modules/vm-configuration/attachments/remote-access-linux-vms/fedora-access-vm.yaml
@@ -5,9 +5,7 @@ metadata:
   namespace: vm-access-demo
 spec:
   dataVolumeTemplates:
-    - apiVersion: cdi.kubevirt.io/v1beta1
-      kind: DataVolume
-      metadata:
+    - metadata:
         name: fedora-access-vm-disk
       spec:
         sourceRef:
@@ -19,33 +17,30 @@ spec:
             requests:
               storage: 30Gi
   runStrategy: RerunOnFailure
+  instancetype:
+    name: u1.large
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
         kubevirt.io/domain: fedora-access-vm
     spec:
       domain:
-        cpu:
-          cores: 2
         devices:
           disks:
-            - disk:
+            - name: rootdisk
+              disk:
                 bus: virtio
-              name: rootdisk
-            - disk:
+            - name: cloudinitdisk
+              disk:
                 bus: virtio
-              name: cloudinitdisk
           interfaces:
-            - masquerade: {}
-              name: default
-          rng: {}
-        machine:
-          type: pc-q35-rhel9.4.0
-        memory:
-          guest: 4Gi
+            - name: default
+              masquerade:
       networks:
         - name: default
-          pod: {}
+          pod:
       volumes:
         - dataVolume:
             name: fedora-access-vm-disk
@@ -55,7 +50,8 @@ spec:
               #cloud-config
               user: fedora
               password: fedora123
-              chpasswd: { expire: false }
+              chpasswd:
+                expire: false
               ssh_pwauth: true
               ssh_authorized_keys:
                 - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC... your-public-key-here

--- a/modules/vm-configuration/attachments/remote-access-linux-vms/fedora-vlan-access-vm.yaml
+++ b/modules/vm-configuration/attachments/remote-access-linux-vms/fedora-vlan-access-vm.yaml
@@ -29,20 +29,18 @@ spec:
       domain:
         devices:
           disks:
-            - name: rootdisk
-              disk:
-                bus: virtio
-            - name: cloudinitdisk
-              disk:
-                bus: virtio
+            - disk: {}
+              name: rootdisk
+            - disk: {}
+              name: cloudinitdisk
           interfaces:
-            - name: default
-              masquerade:
-            - name: vlan-network
-              bridge:
+            - masquerade: {}
+              name: default
+            - bridge: {}
+              name: vlan-network
       networks:
         - name: default
-          pod:
+          pod: {}
         - name: vlan-network
           multus:
             networkName: localnet-vlan-100

--- a/modules/vm-configuration/attachments/remote-access-linux-vms/fedora-vlan-access-vm.yaml
+++ b/modules/vm-configuration/attachments/remote-access-linux-vms/fedora-vlan-access-vm.yaml
@@ -5,9 +5,7 @@ metadata:
   namespace: vm-access-demo
 spec:
   dataVolumeTemplates:
-    - apiVersion: cdi.kubevirt.io/v1beta1
-      kind: DataVolume
-      metadata:
+    - metadata:
         name: fedora-vlan-vm-disk
       spec:
         sourceRef:
@@ -19,35 +17,32 @@ spec:
             requests:
               storage: 30Gi
   runStrategy: RerunOnFailure
+  instancetype:
+    name: u1.large
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
         kubevirt.io/domain: fedora-vlan-vm
     spec:
       domain:
-        cpu:
-          cores: 2
         devices:
           disks:
-            - disk:
+            - name: rootdisk
+              disk:
                 bus: virtio
-              name: rootdisk
-            - disk:
+            - name: cloudinitdisk
+              disk:
                 bus: virtio
-              name: cloudinitdisk
           interfaces:
-            - masquerade: {}
-              name: default
-            - bridge: {}
-              name: vlan-network
-          rng: {}
-        machine:
-          type: pc-q35-rhel9.4.0
-        memory:
-          guest: 4Gi
+            - name: default
+              masquerade:
+            - name: vlan-network
+              bridge:
       networks:
         - name: default
-          pod: {}
+          pod:
         - name: vlan-network
           multus:
             networkName: localnet-vlan-100
@@ -60,7 +55,8 @@ spec:
               #cloud-config
               user: fedora
               password: fedora123
-              chpasswd: { expire: false }
+              chpasswd:
+                expire: false
               ssh_pwauth: true
               ssh_authorized_keys:
                 - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC... your-public-key-here

--- a/modules/vm-configuration/attachments/remote-access-linux-vms/ssh-nodeport-service.yaml
+++ b/modules/vm-configuration/attachments/remote-access-linux-vms/ssh-nodeport-service.yaml
@@ -11,4 +11,3 @@ spec:
     - protocol: TCP
       port: 22
       targetPort: 22
-      nodePort: 30022

--- a/modules/vm-configuration/pages/internal-dns-for-vms.adoc
+++ b/modules/vm-configuration/pages/internal-dns-for-vms.adoc
@@ -60,6 +60,10 @@ spec:
           resources:
             requests:
               storage: 30Gi
+  instancetype:
+    name: u1.large
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -69,18 +73,13 @@ spec:
       domain:
         devices:
           disks:
-            - disk:
-                bus: virtio
+            - disk: {}
               name: rootdisk
-            - disk:
-                bus: virtio
+            - disk: {}
               name: cloudinitdisk
           interfaces:
             - name: default
               masquerade: {}
-        resources:
-          requests:
-            memory: 2Gi
       networks:
         - name: default
           pod: {}

--- a/modules/vm-configuration/pages/node-placement-affinity.adoc
+++ b/modules/vm-configuration/pages/node-placement-affinity.adoc
@@ -156,6 +156,10 @@ metadata:
   namespace: vm-placement
 spec:
   runStrategy: Manual
+  instancetype:
+    name: u1.large
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -164,30 +168,24 @@ spec:
       nodeSelector:
         storage: ssd  # VM will only run on nodes with storage=ssd label
       domain:
-        cpu:
-          cores: 2
-        memory:
-          guest: 4Gi
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+            - name: rootdisk
+              disk: {}
+            - name: cloudinitdisk
+              disk: {}
       volumes:
-      - name: rootdisk
-        containerDisk:
-          image: quay.io/containerdisks/fedora:43
-      - name: cloudinitdisk
-        cloudInitNoCloud:
-          userData: |
-            #cloud-config
-            user: fedora
-            password: fedora
-            chpasswd:
-              expire: false
+        - name: rootdisk
+          containerDisk:
+            image: quay.io/containerdisks/fedora:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd:
+                expire: false
 ----
 
 Apply and start the VM:
@@ -264,6 +262,10 @@ metadata:
   namespace: vm-placement
 spec:
   runStrategy: Manual
+  instancetype:
+    name: u1.large
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -273,41 +275,35 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: gpu
-                operator: In
-                values:
-                - nvidia-t4
-                - nvidia-a100
-              - key: env
-                operator: In
-                values:
-                - production
+              - matchExpressions:
+                  - key: gpu
+                    operator: In
+                    values:
+                      - nvidia-t4
+                      - nvidia-a100
+                  - key: env
+                    operator: In
+                    values:
+                      - production
       domain:
-        cpu:
-          cores: 4
-        memory:
-          guest: 8Gi
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+            - name: rootdisk
+              disk: {}
+            - name: cloudinitdisk
+              disk: {}
       volumes:
-      - name: rootdisk
-        containerDisk:
-          image: quay.io/containerdisks/fedora:43
-      - name: cloudinitdisk
-        cloudInitNoCloud:
-          userData: |
-            #cloud-config
-            user: fedora
-            password: fedora
-            chpasswd:
-              expire: false
+        - name: rootdisk
+          containerDisk:
+            image: quay.io/containerdisks/fedora:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd:
+                expire: false
 ----
 
 Key points:
@@ -332,6 +328,10 @@ metadata:
   namespace: vm-placement
 spec:
   runStrategy: Manual
+  instancetype:
+    name: u1.large
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -340,45 +340,39 @@ spec:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: storage
-                operator: In
-                values:
-                - nvme
-          - weight: 50
-            preference:
-              matchExpressions:
-              - key: storage
-                operator: In
-                values:
-                - ssd
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: storage
+                    operator: In
+                    values:
+                      - nvme
+            - weight: 50
+              preference:
+                matchExpressions:
+                  - key: storage
+                    operator: In
+                    values:
+                      - ssd
       domain:
-        cpu:
-          cores: 2
-        memory:
-          guest: 2Gi
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+            - name: rootdisk
+              disk: {}
+            - name: cloudinitdisk
+              disk: {}
       volumes:
-      - name: rootdisk
-        containerDisk:
-          image: quay.io/containerdisks/fedora:43
-      - name: cloudinitdisk
-        cloudInitNoCloud:
-          userData: |
-            #cloud-config
-            user: fedora
-            password: fedora
-            chpasswd:
-              expire: false
+        - name: rootdisk
+          containerDisk:
+            image: quay.io/containerdisks/fedora:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd:
+                expire: false
 ----
 
 Key points:
@@ -434,6 +428,10 @@ metadata:
   namespace: vm-placement
 spec:
   runStrategy: Manual
+  instancetype:
+    name: u1.large
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -443,38 +441,32 @@ spec:
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - database
-            topologyKey: kubernetes.io/hostname
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - database
+              topologyKey: kubernetes.io/hostname
       domain:
-        cpu:
-          cores: 2
-        memory:
-          guest: 2Gi
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+            - name: rootdisk
+              disk: {}
+            - name: cloudinitdisk
+              disk: {}
       volumes:
-      - name: rootdisk
-        containerDisk:
-          image: quay.io/containerdisks/fedora:43
-      - name: cloudinitdisk
-        cloudInitNoCloud:
-          userData: |
-            #cloud-config
-            user: fedora
-            password: fedora
-            chpasswd:
-              expire: false
+        - name: rootdisk
+          containerDisk:
+            image: quay.io/containerdisks/fedora:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd:
+                expire: false
 ----
 
 This VM will run on the same node (`topologyKey: kubernetes.io/hostname`) as pods/VMs with `app=database`.
@@ -510,6 +502,10 @@ metadata:
   namespace: vm-placement
 spec:
   runStrategy: Manual
+  instancetype:
+    name: u1.large
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
@@ -519,38 +515,32 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - redis-cache
-            topologyKey: kubernetes.io/hostname
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - redis-cache
+              topologyKey: kubernetes.io/hostname
       domain:
-        cpu:
-          cores: 2
-        memory:
-          guest: 4Gi
         devices:
           disks:
-          - name: rootdisk
-            disk:
-              bus: virtio
-          - name: cloudinitdisk
-            disk:
-              bus: virtio
+            - name: rootdisk
+              disk: {}
+            - name: cloudinitdisk
+              disk: {}
       volumes:
-      - name: rootdisk
-        containerDisk:
-          image: quay.io/containerdisks/fedora:43
-      - name: cloudinitdisk
-        cloudInitNoCloud:
-          userData: |
-            #cloud-config
-            user: fedora
-            password: fedora
-            chpasswd:
-              expire: false
+        - name: rootdisk
+          containerDisk:
+            image: quay.io/containerdisks/fedora:43
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: fedora
+              password: fedora
+              chpasswd:
+                expire: false
 ----
 
 This ensures multiple cache VMs never run on the same node, improving availability.

--- a/modules/vm-configuration/pages/remote-access-linux-vms.adoc
+++ b/modules/vm-configuration/pages/remote-access-linux-vms.adoc
@@ -67,9 +67,7 @@ metadata:
   namespace: vm-access-demo
 spec:
   dataVolumeTemplates:
-    - apiVersion: cdi.kubevirt.io/v1beta1
-      kind: DataVolume
-      metadata:
+    - metadata:
         name: fedora-access-vm-disk
       spec:
         sourceRef:
@@ -81,33 +79,30 @@ spec:
             requests:
               storage: 30Gi
   runStrategy: RerunOnFailure
+  instancetype:
+    name: u1.large
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
         kubevirt.io/domain: fedora-access-vm
     spec:
       domain:
-        cpu:
-          cores: 2
         devices:
           disks:
-            - disk:
+            - name: rootdisk
+              disk:
                 bus: virtio
-              name: rootdisk
-            - disk:
+            - name: cloudinitdisk
+              disk:
                 bus: virtio
-              name: cloudinitdisk
           interfaces:
-            - masquerade: {}
-              name: default
-          rng: {}
-        machine:
-          type: pc-q35-rhel9.4.0
-        memory:
-          guest: 4Gi
+            - name: default
+              masquerade:
       networks:
         - name: default
-          pod: {}
+          pod:
       volumes:
         - dataVolume:
             name: fedora-access-vm-disk
@@ -253,7 +248,6 @@ spec:
     - protocol: TCP
       port: 22
       targetPort: 22
-      nodePort: 30022
 ----
 
 Apply the service:
@@ -270,20 +264,23 @@ oc apply -f fedora-ssh-nodeport.yaml
 oc get svc fedora-ssh-nodeport -n vm-access-demo
 ----
 
+Note the assigned NodePort in the output (will be in the range 30000-32767).
+
 === Connect via SSH
 
-Get your cluster node IP:
+Get your cluster node IP and the assigned NodePort:
 
 [source,bash,role=execute]
 ----
 oc get nodes -o wide
+oc get svc fedora-ssh-nodeport -n vm-access-demo -o jsonpath='{.spec.ports[0].nodePort}'
 ----
 
 Connect using the NodePort:
 
 [source,bash,role=execute]
 ----
-ssh fedora@<node-ip> -p 30022
+ssh fedora@<node-ip> -p <nodeport>
 ----
 
 === When to Use
@@ -371,9 +368,7 @@ metadata:
   namespace: vm-access-demo
 spec:
   dataVolumeTemplates:
-    - apiVersion: cdi.kubevirt.io/v1beta1
-      kind: DataVolume
-      metadata:
+    - metadata:
         name: fedora-vlan-vm-disk
       spec:
         sourceRef:
@@ -385,35 +380,32 @@ spec:
             requests:
               storage: 30Gi
   runStrategy: RerunOnFailure
+  instancetype:
+    name: u1.large
+  preference:
+    name: fedora
   template:
     metadata:
       labels:
         kubevirt.io/domain: fedora-vlan-vm
     spec:
       domain:
-        cpu:
-          cores: 2
         devices:
           disks:
-            - disk:
+            - name: rootdisk
+              disk:
                 bus: virtio
-              name: rootdisk
-            - disk:
+            - name: cloudinitdisk
+              disk:
                 bus: virtio
-              name: cloudinitdisk
           interfaces:
-            - masquerade: {}
-              name: default
-            - bridge: {}
-              name: vlan-network
-          rng: {}
-        machine:
-          type: pc-q35-rhel9.4.0
-        memory:
-          guest: 4Gi
+            - name: default
+              masquerade:
+            - name: vlan-network
+              bridge:
       networks:
         - name: default
-          pod: {}
+          pod:
         - name: vlan-network
           multus:
             networkName: localnet-vlan-100
@@ -584,7 +576,7 @@ For troubleshooting of all access methods, see xref:remote-access-linux-troubles
 
 **Problem**: SSH service not running or authentication failure.
 
-**Solution**: 
+**Solution**:
 
 * Verify SSH service is running in the VM
 * Check that SSH keys are properly configured

--- a/modules/vm-configuration/pages/remote-access-linux-vms.adoc
+++ b/modules/vm-configuration/pages/remote-access-linux-vms.adoc
@@ -91,18 +91,16 @@ spec:
       domain:
         devices:
           disks:
-            - name: rootdisk
-              disk:
-                bus: virtio
-            - name: cloudinitdisk
-              disk:
-                bus: virtio
+            - disk: {}
+              name: rootdisk
+            - disk: {}
+              name: cloudinitdisk
           interfaces:
-            - name: default
-              masquerade:
+            - masquerade: {}
+              name: default
       networks:
         - name: default
-          pod:
+          pod: {}
       volumes:
         - dataVolume:
             name: fedora-access-vm-disk
@@ -392,20 +390,18 @@ spec:
       domain:
         devices:
           disks:
-            - name: rootdisk
-              disk:
-                bus: virtio
-            - name: cloudinitdisk
-              disk:
-                bus: virtio
+            - disk: {}
+              name: rootdisk
+            - disk: {}
+              name: cloudinitdisk
           interfaces:
-            - name: default
-              masquerade:
-            - name: vlan-network
-              bridge:
+            - masquerade: {}
+              name: default
+            - bridge: {}
+              name: vlan-network
       networks:
         - name: default
-          pod:
+          pod: {}
         - name: vlan-network
           multus:
             networkName: localnet-vlan-100


### PR DESCRIPTION
  - Convert node-placement-affinity, remote-access-linux-vms, and internal-dns-for-vms
  to use instancetype/preference (scheduling fields and access-method config preserved)
  - Remove hardcoded NodePort 30022 in remote-access-linux-vms to avoid port conflicts
  - Keep hotplug-volumes-interfaces and disk-io-tuning with explicit domain specs
  (device config is the lesson)
  - Tested all 3 converted tutorials against live cluster — all VMs deploy and function
  correctly

closes #349 